### PR TITLE
fix(write): honor --height argument

### DIFF
--- a/write/command.go
+++ b/write/command.go
@@ -29,6 +29,7 @@ func (o Options) Run() {
 	a.BlurredStyle.Prompt = lipgloss.NewStyle().Foreground(lipgloss.Color(o.PromptColor))
 
 	a.SetWidth(o.Width)
+	a.SetHeight(o.Height)
 
 	p := tea.NewProgram(model{a}, tea.WithOutput(os.Stderr))
 	m, _ := p.StartReturningModel()


### PR DESCRIPTION
Just a tiny fix that wires up the `--height` argument in `gum write`.