### PR TITLE
feat: Add flag(s) to filter for file and directory filtering

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/charmbracelet/gum/internal/files"
 	"github.com/charmbracelet/gum/internal/stdin"
 	"github.com/charmbracelet/gum/style"
@@ -29,7 +30,7 @@ func (o Options) Run() error {
 	if input != "" {
 		choices = strings.Split(string(input), "\n")
 	} else {
-		choices = files.List()
+		choices = files.List(o.FileListOptions)
 	}
 
 	p := tea.NewProgram(model{

--- a/filter/options.go
+++ b/filter/options.go
@@ -1,15 +1,19 @@
 package filter
 
-import "github.com/charmbracelet/gum/style"
+import (
+	"github.com/charmbracelet/gum/internal/files"
+	"github.com/charmbracelet/gum/style"
+)
 
 // Options is the customization options for the filter command.
 type Options struct {
-	Indicator      string       `help:"Character for selection" default:"•"`
-	IndicatorStyle style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" set:"name=indicator"`
-	TextStyle      style.Styles `embed:"" prefix:"text."`
-	MatchStyle     style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" set:"name=matched text"`
-	Placeholder    string       `help:"Placeholder value" default:"Filter..."`
-	Prompt         string       `help:"Prompt to display" default:"> "`
-	PromptStyle    style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" set:"name=prompt"`
-	Width          int          `help:"Input width" default:"20"`
+	Indicator       string            `help:"Character for selection" default:"•"`
+	IndicatorStyle  style.Styles      `embed:"" prefix:"indicator." set:"defaultForeground=212" set:"name=indicator"`
+	TextStyle       style.Styles      `embed:"" prefix:"text."`
+	MatchStyle      style.Styles      `embed:"" prefix:"match." set:"defaultForeground=212" set:"name=matched text"`
+	Placeholder     string            `help:"Placeholder value" default:"Filter..."`
+	Prompt          string            `help:"Prompt to display" default:"> "`
+	PromptStyle     style.Styles      `embed:"" prefix:"prompt." set:"defaultForeground=240" set:"name=prompt"`
+	Width           int               `help:"Input width" default:"20"`
+	FileListOptions files.ListOptions `embed:"" prefix:"files." set:"recursive=true "`
 }

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -8,13 +8,22 @@ import (
 
 // List returns a list of all files in the current directory.
 // It ignores the .git directory.
-func List() []string {
+func List(opts ListOptions) []string {
 	var files []string
+
 	err := filepath.Walk(".",
 		func(path string, info os.FileInfo, err error) error {
-			if shouldIgnore(path) || info.IsDir() || err != nil {
+			switch {
+			case err != nil:
+				return nil
+			case shouldIgnore(path):
+				return nil
+			case info.IsDir() && !opts.OnlyDirectories:
+				return nil
+			case !info.IsDir() && opts.OnlyDirectories:
 				return nil
 			}
+
 			files = append(files, path)
 			return nil
 		})
@@ -22,8 +31,8 @@ func List() []string {
 	if err != nil {
 		return []string{}
 	}
-	return files
 
+	return files
 }
 
 var defaultIgnorePatterns = []string{"node_modules", ".git", "."}
@@ -34,5 +43,6 @@ func shouldIgnore(path string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/internal/files/options.go
+++ b/internal/files/options.go
@@ -1,0 +1,9 @@
+package files
+
+// ListOptions is a flag set containing options
+// which control the output of List.
+//
+// This flag set is primarily used by the filter command.
+type ListOptions struct {
+	OnlyDirectories bool `help:"Only return directory names in results (in other words, omit file names)" default:"false" group:"File Listing Flags"`
+}


### PR DESCRIPTION
This commit adds a new flag set to filter.Options, containing (as of
now) one flag: `OnlyDirectories` (`--only-directories`). This flag, when
true, causes `files.List()` to **not** ignore directories, and instead
only return directory names rather than only returning file names.

changes:
- create flag set with options for files.List()
- add files.ListOptions flags to filter.Options

Closes #21

feat: implement ListOptions usage in List