### PR TITLE
Add `--password` option for masked input

### DIFF
--- a/input/command.go
+++ b/input/command.go
@@ -31,6 +31,11 @@ func (o Options) Run() error {
 	i.PromptStyle = o.PromptStyle.ToLipgloss()
 	i.CursorStyle = o.CursorStyle.ToLipgloss()
 
+	if o.Password {
+		i.EchoMode = textinput.EchoPassword
+		i.EchoCharacter = '•'
+	}
+
 	p := tea.NewProgram(model{i}, tea.WithOutput(os.Stderr))
 	m, err := p.StartReturningModel()
 	fmt.Println(m.(model).textinput.Value())

--- a/input/options.go
+++ b/input/options.go
@@ -10,4 +10,5 @@ type Options struct {
 	CursorStyle style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" set:"name=cursor"`
 	Value       string       `help:"Initial value (can also be passed via stdin)" default:""`
 	Width       int          `help:"Input width" default:"40"`
+	Password    bool         `help:"Mask input characters" default:"false"`
 }


### PR DESCRIPTION
Fixes #28

Adds `--password` flag to `gum input` to mask characters while typing for
passwords.
