### PR TITLE
Added option for custom delimiter in filter command

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -27,7 +27,7 @@ func (o Options) Run() error {
 
 	var choices []string
 	if input, _ := stdin.Read(); input != "" {
-		choices = strings.Split(strings.TrimSpace(input), "\n")
+		choices = strings.Split(strings.TrimSpace(input), o.Delimeter)
 	} else {
 		choices = files.List()
 	}

--- a/filter/options.go
+++ b/filter/options.go
@@ -13,4 +13,5 @@ type Options struct {
 	Prompt         string       `help:"Prompt to display" default:"> "`
 	PromptStyle    style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" set:"name=prompt"`
 	Width          int          `help:"Input width" default:"20"`
+    Delimeter      string       `help:"Delimeter to split input on" default:"\n"`
 }

--- a/filter/options.go
+++ b/filter/options.go
@@ -13,5 +13,5 @@ type Options struct {
 	Prompt         string       `help:"Prompt to display" default:"> "`
 	PromptStyle    style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" set:"name=prompt"`
 	Width          int          `help:"Input width" default:"20"`
-    Delimeter      string       `help:"Delimeter to split input on" default:"\n"`
+    Delimeter      string       "help:\"Delimeter to split input on\" default:\"\n\""
 }


### PR DESCRIPTION
I wanted to be able to configure the parsing of the input list for the filter command so it could take a list of space separated values instead of just newline separated values. An example of the new behavior would be:

```SH
echo "candy waffles ice-cream" | ./gum filter --delimiter=" "
> Filter...
• candy   
  waffles 
  icecream
```