### PR TITLE
feat: select/deselect all items in gum choose with a/A

### DIFF
--- a/choose/choose.go
+++ b/choose/choose.go
@@ -71,6 +71,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "left", "h", "ctrl+b":
 			m.index = clamp(m.index-m.height, 0, len(m.items)-1)
 			m.paginator.PrevPage()
+		case "a":
+			for i := range m.items {
+				m.items[i].selected = true
+			}
+			m.numSelected = len(m.items)
+		case "A":
+			for i := range m.items {
+				m.items[i].selected = false
+			}
+			m.numSelected = 0
 		case "ctrl+c":
 			m.aborted = true
 			m.quitting = true

--- a/choose/choose.go
+++ b/choose/choose.go
@@ -72,11 +72,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.index = clamp(m.index-m.height, 0, len(m.items)-1)
 			m.paginator.PrevPage()
 		case "a":
+			if m.limit <= 1 {
+				break
+			}
 			for i := range m.items {
 				m.items[i].selected = true
 			}
 			m.numSelected = len(m.items)
 		case "A":
+			if m.limit <= 1 {
+				break
+			}
 			for i := range m.items {
 				m.items[i].selected = false
 			}


### PR DESCRIPTION
Fixes #85 when running `gum choose` with limit > 1

### Changes
- Add <kbd>a</kbd> keybinding to select all items in `gum choose`
- Add <kbd>A</kbd> keybinding to deselect all items in `gum choose`

https://user-images.githubusercontent.com/6196971/182436274-ee8f1099-4c95-485b-b7cf-3f49a4503f8c.mov


