### PR TITLE
feat: Make input and write textarea CharLimit configurable

### DIFF
--- a/input/command.go
+++ b/input/command.go
@@ -28,6 +28,7 @@ func (o Options) Run() error {
 	i.Width = o.Width
 	i.PromptStyle = o.PromptStyle.ToLipgloss()
 	i.CursorStyle = o.CursorStyle.ToLipgloss()
+	i.CharLimit = o.CharLimit
 
 	if o.Password {
 		i.EchoMode = textinput.EchoPassword

--- a/input/options.go
+++ b/input/options.go
@@ -10,6 +10,7 @@ type Options struct {
 	PromptStyle style.Styles `embed:"" prefix:"prompt." set:"name=prompt"`
 	CursorStyle style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" set:"name=cursor"`
 	Value       string       `help:"Initial value (can also be passed via stdin)" default:""`
+	CharLimit   int          `help:"Maximum value length (0 for no limit)" default:"400"`
 	Width       int          `help:"Input width" default:"40"`
 	Password    bool         `help:"Mask input characters" default:"false"`
 }

--- a/write/command.go
+++ b/write/command.go
@@ -26,6 +26,7 @@ func (o Options) Run() error {
 	a.Prompt = o.Prompt
 	a.Placeholder = o.Placeholder
 	a.ShowLineNumbers = o.ShowLineNumbers
+	a.CharLimit = o.CharLimit
 
 	style := textarea.Style{
 		Base:             o.BaseStyle.ToLipgloss(),

--- a/write/options.go
+++ b/write/options.go
@@ -12,6 +12,7 @@ type Options struct {
 	ShowCursorLine  bool   `help:"Show cursor line" default:"false"`
 	ShowLineNumbers bool   `help:"Show line numbers" default:"false"`
 	Value           string `help:"Initial value (can be passed via stdin)" default:""`
+	CharLimit       int    `help:"Maximum value length (0 for no limit)" default:"400"`
 
 	BaseStyle             style.Styles `embed:"" prefix:"base." set:"name=base"`
 	CursorLineNumberStyle style.Styles `embed:"" prefix:"cursor-line-number." set:"defaultForeground=7" set:"name=cursor line number"`


### PR DESCRIPTION
Removes the hardcoded 400 chars CharLimit (default for textarea), and make the CharLimit configurable through an Option.

Fixes #...

### Changes
- Add a `CharLimit` Option to `input` that defaults to the current hardcoded value ( [textarea default CharLimit](https://github.com/charmbracelet/bubbles/blob/master/textarea/textarea.go#L22) )
- Add a `CharLimit` Option to `write` that defaults to the current hardcoded value ( [textarea default CharLimit](https://github.com/charmbracelet/bubbles/blob/master/textarea/textarea.go#L22) )

