### PR TITLE
Environment Variable Configuration

### DIFF
--- a/choose/options.go
+++ b/choose/options.go
@@ -9,12 +9,12 @@ type Options struct {
 
 	Limit             int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit           bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
-	Height            int          `help:"Height of the list" default:"10"`
-	Cursor            string       `help:"Prefix to show on item that corresponds to the cursor position" default:"> "`
-	CursorPrefix      string       `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"[•] "`
-	SelectedPrefix    string       `help:"Prefix to show on selected items (hidden if limit is 1)" default:"[✕] "`
-	UnselectedPrefix  string       `help:"Prefix to show on selected items (hidden if limit is 1)" default:"[ ] "`
-	CursorStyle       style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212"`
-	ItemStyle         style.Styles `embed:"" prefix:"item." hidden:""`
-	SelectedItemStyle style.Styles `embed:"" prefix:"selected." set:"defaultForeground=212"`
+	Height            int          `help:"Height of the list" default:"10" env:"GUM_CHOOSE_HEIGHT"`
+	Cursor            string       `help:"Prefix to show on item that corresponds to the cursor position" default:"> " env:"GUM_CHOOSE_CURSOR"`
+	CursorPrefix      string       `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"[•] " env:"GUM_CHOOSE_CURSOR_PREFIX"`
+	SelectedPrefix    string       `help:"Prefix to show on selected items (hidden if limit is 1)" default:"[✕] " env:"GUM_CHOOSE_SELECTED_PREFIX"`
+	UnselectedPrefix  string       `help:"Prefix to show on selected items (hidden if limit is 1)" default:"[ ] " env:"GUM_CHOOSE_UNSELECTED_PREFIX"`
+	CursorStyle       style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_CURSOR_"`
+	ItemStyle         style.Styles `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`
+	SelectedItemStyle style.Styles `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_"`
 }

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -9,7 +9,7 @@ type Options struct {
 	Negative        string       `help:"The title of the negative action" default:"No"`
 	Default         bool         `help:"Default confirmation action" default:"true"`
 	Prompt          string       `arg:"" help:"Prompt to display." default:"Are you sure?"`
-	PromptStyle     style.Styles `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0"`
-	UnselectedStyle style.Styles `embed:"" prefix:"unselected." help:"The style of the unselected action" set:"defaultBackground=235" set:"defaultForeground=254" set:"defaultPadding=0 3" set:"defaultMargin=1 1"`
-	SelectedStyle   style.Styles `embed:"" prefix:"selected." help:"The style of the selected action" set:"defaultBackground=212" set:"defaultForeground=230" set:"defaultPadding=0 3" set:"defaultMargin=1 1"`
+	PromptStyle     style.Styles `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
+	SelectedStyle   style.Styles `embed:"" prefix:"selected." help:"The style of the selected action" set:"defaultBackground=212" set:"defaultForeground=230" set:"defaultPadding=0 3" set:"defaultMargin=1 1" envprefix:"GUM_CONFIRM_SELECTED_"`
+	UnselectedStyle style.Styles `embed:"" prefix:"unselected." help:"The style of the unselected action" set:"defaultBackground=235" set:"defaultForeground=254" set:"defaultPadding=0 3" set:"defaultMargin=1 1" envprefix:"GUM_CONFIRM_UNSELECTED_"`
 }

--- a/filter/options.go
+++ b/filter/options.go
@@ -5,13 +5,13 @@ import "github.com/charmbracelet/gum/style"
 // Options is the customization options for the filter command.
 // nolint:staticcheck
 type Options struct {
-	Indicator      string       `help:"Character for selection" default:"•"`
-	IndicatorStyle style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212"`
-	TextStyle      style.Styles `embed:"" prefix:"text."`
-	MatchStyle     style.Styles `embed:"" prefix:"match." set:"defaultForeground=212"`
-	Placeholder    string       `help:"Placeholder value" default:"Filter..."`
-	Prompt         string       `help:"Prompt to display" default:"> "`
-	PromptStyle    style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240"`
-	Width          int          `help:"Input width" default:"20"`
-	Height         int          `help:"Input height" default:"0"`
+	Indicator      string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
+	IndicatorStyle style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
+	TextStyle      style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
+	MatchStyle     style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
+	Placeholder    string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
+	Prompt         string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
+	PromptStyle    style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
+	Width          int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
+	Height         int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
 }

--- a/input/options.go
+++ b/input/options.go
@@ -5,12 +5,12 @@ import "github.com/charmbracelet/gum/style"
 // Options are the customization options for the input.
 // nolint:staticcheck
 type Options struct {
-	Placeholder string       `help:"Placeholder value" default:"Type something..."`
-	Prompt      string       `help:"Prompt to display" default:"> "`
-	PromptStyle style.Styles `embed:"" prefix:"prompt."`
-	CursorStyle style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212"`
+	Placeholder string       `help:"Placeholder value" default:"Type something..." env:"GUM_INPUT_PLACEHOLDER"`
+	Prompt      string       `help:"Prompt to display" default:"> " env:"GUM_INPUT_PROMPT"`
+	PromptStyle style.Styles `embed:"" prefix:"prompt." envprefix:"GUM_INPUT_PROMPT_"`
+	CursorStyle style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_INPUT_CURSOR_"`
 	Value       string       `help:"Initial value (can also be passed via stdin)" default:""`
 	CharLimit   int          `help:"Maximum value length (0 for no limit)" default:"400"`
-	Width       int          `help:"Input width" default:"40"`
+	Width       int          `help:"Input width" default:"40" env:"GUM_INPUT_WIDTH"`
 	Password    bool         `help:"Mask input characters" default:"false"`
 }

--- a/spin/options.go
+++ b/spin/options.go
@@ -7,9 +7,9 @@ import "github.com/charmbracelet/gum/style"
 type Options struct {
 	Command []string `arg:"" help:"Command to run"`
 
-	ShowOutput   bool         `help:"Show output of command" default:"false"`
-	Spinner      string       `help:"Spinner type" short:"s" type:"spinner" enum:"line,dot,minidot,jump,pulse,points,globe,moon,monkey,meter,hamburger" default:"dot"`
-	SpinnerStyle style.Styles `embed:"" prefix:"spinner." set:"defaultForeground=212"`
-	Title        string       `help:"Text to display to user while spinning" default:"Loading..."`
-	TitleStyle   style.Styles `embed:"" prefix:"title."`
+	ShowOutput   bool         `help:"Show output of command" default:"false" env:"GUM_SPIN_SHOW_OUTPUT"`
+	Spinner      string       `help:"Spinner type" short:"s" type:"spinner" enum:"line,dot,minidot,jump,pulse,points,globe,moon,monkey,meter,hamburger" default:"dot" env:"GUM_SPIN_SPINNER"`
+	SpinnerStyle style.Styles `embed:"" prefix:"spinner." set:"defaultForeground=212" envprefix:"GUM_SPIN_SPINNER_"`
+	Title        string       `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`
+	TitleStyle   style.Styles `embed:"" prefix:"title." envprefix:"GUM_SPIN_TITLE_"`
 }

--- a/style/options.go
+++ b/style/options.go
@@ -18,25 +18,25 @@ type Options struct {
 // components, through embedding and prefixing.
 type Styles struct {
 	// Colors
-	Background string `help:"Background Color" default:"${defaultBackground}" group:"Style Flags"`
-	Foreground string `help:"Foreground Color" default:"${defaultForeground}" group:"Style Flags"`
+	Background string `help:"Background Color" default:"${defaultBackground}" group:"Style Flags" env:"BACKGROUND"`
+	Foreground string `help:"Foreground Color" default:"${defaultForeground}" group:"Style Flags" env:"FOREGROUND"`
 
 	// Border
-	Border           string `help:"Border Style" enum:"none,hidden,normal,rounded,thick,double" default:"none" group:"Style Flags"`
-	BorderBackground string `help:"Border Background Color" group:"Style Flags"`
-	BorderForeground string `help:"Border Foreground Color" group:"Style Flags"`
+	Border           string `help:"Border Style" enum:"none,hidden,normal,rounded,thick,double" default:"none" group:"Style Flags" env:"BORDER"`
+	BorderBackground string `help:"Border Background Color" group:"Style Flags" env:"BORDER_BACKGROUND"`
+	BorderForeground string `help:"Border Foreground Color" group:"Style Flags" env:"BORDER_FOREGROUND"`
 
 	// Layout
-	Align   string `help:"Text Alignment" enum:"left,center,right,bottom,middle,top" default:"left" group:"Style Flags"`
-	Height  int    `help:"Text height" group:"Style Flags"`
-	Width   int    `help:"Text width" group:"Style Flags"`
-	Margin  string `help:"Text margin" default:"${defaultMargin}" group:"Style Flags"`
-	Padding string `help:"Text padding" default:"${defaultPadding}" group:"Style Flags"`
+	Align   string `help:"Text Alignment" enum:"left,center,right,bottom,middle,top" default:"left" group:"Style Flags" env:"ALIGN"`
+	Height  int    `help:"Text height" group:"Style Flags" env:"HEIGHT"`
+	Width   int    `help:"Text width" group:"Style Flags" env:"WIDTH"`
+	Margin  string `help:"Text margin" default:"${defaultMargin}" group:"Style Flags" env:"MARGIN"`
+	Padding string `help:"Text padding" default:"${defaultPadding}" group:"Style Flags" env:"PADDING"`
 
 	// Format
-	Bold          bool `help:"Bold text" group:"Style Flags"`
-	Faint         bool `help:"Faint text" group:"Style Flags"`
-	Italic        bool `help:"Italicize text" group:"Style Flags"`
-	Strikethrough bool `help:"Strikethrough text" group:"Style Flags"`
-	Underline     bool `help:"Underline text" default:"${defaultUnderline}" group:"Style Flags"`
+	Bold          bool `help:"Bold text" group:"Style Flags" env:"BOLD"`
+	Faint         bool `help:"Faint text" group:"Style Flags" env:"FAINT"`
+	Italic        bool `help:"Italicize text" group:"Style Flags" env:"ITALIC"`
+	Strikethrough bool `help:"Strikethrough text" group:"Style Flags" env:"STRIKETHROUGH"`
+	Underline     bool `help:"Underline text" default:"${defaultUnderline}" group:"Style Flags" env:"UNDERLINE"`
 }

--- a/write/options.go
+++ b/write/options.go
@@ -5,21 +5,21 @@ import "github.com/charmbracelet/gum/style"
 // Options are the customization options for the textarea.
 // nolint:staticcheck
 type Options struct {
-	Width           int    `help:"Text area width" default:"50"`
-	Height          int    `help:"Text area height" default:"5"`
-	Placeholder     string `help:"Placeholder value" default:"Write something..."`
-	Prompt          string `help:"Prompt to display" default:"┃ "`
-	ShowCursorLine  bool   `help:"Show cursor line" default:"false"`
-	ShowLineNumbers bool   `help:"Show line numbers" default:"false"`
-	Value           string `help:"Initial value (can be passed via stdin)" default:""`
+	Width           int    `help:"Text area width" default:"50" env:"GUM_WRITE_WIDTH"`
+	Height          int    `help:"Text area height" default:"5" env:"GUM_WRITE_HEIGHT"`
+	Placeholder     string `help:"Placeholder value" default:"Write something..." env:"GUM_WRITE_PLACEHOLDER"`
+	Prompt          string `help:"Prompt to display" default:"┃ " env:"GUM_WRITE_PROMPT"`
+	ShowCursorLine  bool   `help:"Show cursor line" default:"false" env:"GUM_WRITE_SHOW_CURSOR_LINE"`
+	ShowLineNumbers bool   `help:"Show line numbers" default:"false" env:"GUM_WRITE_SHOW_LINE_NUMBERS"`
+	Value           string `help:"Initial value (can be passed via stdin)" default:"" env:"GUM_WRITE_VALUE"`
 	CharLimit       int    `help:"Maximum value length (0 for no limit)" default:"400"`
 
-	BaseStyle             style.Styles `embed:"" prefix:"base."`
-	CursorLineNumberStyle style.Styles `embed:"" prefix:"cursor-line-number." set:"defaultForeground=7"`
-	CursorLineStyle       style.Styles `embed:"" prefix:"cursor-line."`
-	CursorStyle           style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212"`
-	EndOfBufferStyle      style.Styles `embed:"" prefix:"end-of-buffer." set:"defaultForeground=0"`
-	LineNumberStyle       style.Styles `embed:"" prefix:"line-number." set:"defaultForeground=7"`
-	PlaceholderStyle      style.Styles `embed:"" prefix:"placeholder." set:"defaultForeground=240"`
-	PromptStyle           style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=7"`
+	BaseStyle             style.Styles `embed:"" prefix:"base." envprefix:"GUM_WRITE_BASE_"`
+	CursorLineNumberStyle style.Styles `embed:"" prefix:"cursor-line-number." set:"defaultForeground=7" envprefix:"GUM_WRITE_CURSOR_LINE_NUMBER_"`
+	CursorLineStyle       style.Styles `embed:"" prefix:"cursor-line." envprefix:"GUM_WRITE_CURSOR_LINE_"`
+	CursorStyle           style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_WRITE_CURSOR_"`
+	EndOfBufferStyle      style.Styles `embed:"" prefix:"end-of-buffer." set:"defaultForeground=0" envprefix:"GUM_WRITE_END_OF_BUFFER_"`
+	LineNumberStyle       style.Styles `embed:"" prefix:"line-number." set:"defaultForeground=7" envprefix:"GUM_WRITE_LINE_NUMBER_"`
+	PlaceholderStyle      style.Styles `embed:"" prefix:"placeholder." set:"defaultForeground=240" envprefix:"GUM_WRITE_PLACEHOLDER_"`
+	PromptStyle           style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=7" envprefix:"GUM_WRITE_PROMPT_"`
 }


### PR DESCRIPTION
### Changes
- Allow most aspects of gum (mainly theming) to be configured by default
  through `ENV_VARS` and be overridden by `--flags`

Generally the environment variables follow the following scheme:
1. `GUM_`
2. `<COMMAND>_`
3. `FLAG` (replace `-` and `.` with `_`)

For example, `gum filter` can be customized by default through the following flags:
```bash
export GUM_FILTER_INDICATOR="*"
export GUM_FILTER_INDICATOR_FOREGROUND=1
export GUM_FILTER_PROMPT="→"
export GUM_FILTER_PROMPT_FOREGROUND=1

# command will now use default customization from the environment variables but
# can still be overridden by flags.
gum filter
```
