### PR TITLE
Add default timeout on confirm options & messages

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -17,6 +17,8 @@ func (o Options) Run() error {
 		affirmative:     o.Affirmative,
 		negative:        o.Negative,
 		confirmation:    o.Default,
+		timeout:         o.Timeout,
+		timeoutmsg:      o.TimeoutMsg,
 		prompt:          o.Prompt,
 		selectedStyle:   o.SelectedStyle.ToLipgloss(),
 		unselectedStyle: o.UnselectedStyle.ToLipgloss(),

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -18,7 +18,6 @@ func (o Options) Run() error {
 		negative:        o.Negative,
 		confirmation:    o.Default,
 		timeout:         o.Timeout,
-		timeoutmsg:      o.TimeoutMsg,
 		prompt:          o.Prompt,
 		selectedStyle:   o.SelectedStyle.ToLipgloss(),
 		unselectedStyle: o.UnselectedStyle.ToLipgloss(),

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -18,6 +18,7 @@ func (o Options) Run() error {
 		negative:        o.Negative,
 		confirmation:    o.Default,
 		timeout:         o.Timeout,
+		hasTimeout:      o.Timeout > 0,
 		prompt:          o.Prompt,
 		selectedStyle:   o.SelectedStyle.ToLipgloss(),
 		unselectedStyle: o.UnselectedStyle.ToLipgloss(),

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -24,7 +24,6 @@ type model struct {
 	negative    string
 	quitting    bool
 	timeout     int
-	timeoutmsg  string
 
 	confirmation bool
 

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -80,7 +80,7 @@ func updateChoices(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			m.confirmation = false
 			return m, tea.Quit
 		}
-		m.timeout -= 1
+		m.timeout--
 		return m, tick()
 	}
 	return m, nil

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -92,21 +92,17 @@ func (m model) View() string {
 		return ""
 	}
 
-	var aff, neg, timeoutMessage string
+	var aff, neg, negativeMessage string
 
-	timeoutMessage = fmt.Sprintf("%s %d", m.timeoutmsg, m.timeout)
+	negativeMessage = fmt.Sprintf("%s(%d)", m.negative, m.timeout)
 
 	if m.confirmation {
 		aff = m.selectedStyle.Render(m.affirmative)
-		neg = m.unselectedStyle.Render(m.negative)
+		neg = m.unselectedStyle.Render(negativeMessage)
 	} else {
 		aff = m.unselectedStyle.Render(m.affirmative)
-		neg = m.selectedStyle.Render(m.negative)
+		neg = m.selectedStyle.Render(negativeMessage)
 	}
 
-	return lipgloss.JoinVertical(
-		lipgloss.Center,
-		m.promptStyle.Render(m.prompt),
-		m.promptStyle.Render(timeoutMessage),
-		lipgloss.JoinHorizontal(lipgloss.Left, aff, neg))
+	return lipgloss.JoinVertical(lipgloss.Center, m.promptStyle.Render(m.prompt), lipgloss.JoinHorizontal(lipgloss.Left, aff, neg))
 }

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -1,15 +1,19 @@
 package confirm
 
-import "github.com/charmbracelet/gum/style"
+import (
+	"time"
+
+	"github.com/charmbracelet/gum/style"
+)
 
 // Options is the customization options for the confirm command.
 type Options struct {
-	Affirmative string       `help:"The title of the affirmative action" default:"Yes"`
-	Negative    string       `help:"The title of the negative action" default:"No"`
-	Default     bool         `help:"Default confirmation action" default:"true"`
-	Timeout     int          `help:"Timeout for confirmation in seconds" default:"15" env:"GUM_CONFIRM_TIMEOUT"`
-	Prompt      string       `arg:"" help:"Prompt to display." default:"Are you sure?"`
-	PromptStyle style.Styles `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
+	Affirmative string        `help:"The title of the affirmative action" default:"Yes"`
+	Negative    string        `help:"The title of the negative action" default:"No"`
+	Default     bool          `help:"Default confirmation action" default:"true"`
+	Timeout     time.Duration `help:"Timeout for confirmation" default:"0" env:"GUM_CONFIRM_TIMEOUT"`
+	Prompt      string        `arg:"" help:"Prompt to display." default:"Are you sure?"`
+	PromptStyle style.Styles  `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
 	//nolint:staticcheck
 	SelectedStyle style.Styles `embed:"" prefix:"selected." help:"The style of the selected action" set:"defaultBackground=212" set:"defaultForeground=230" set:"defaultPadding=0 3" set:"defaultMargin=1 1" envprefix:"GUM_CONFIRM_SELECTED_"`
 	//nolint:staticcheck

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -7,6 +7,8 @@ type Options struct {
 	Affirmative string       `help:"The title of the affirmative action" default:"Yes"`
 	Negative    string       `help:"The title of the negative action" default:"No"`
 	Default     bool         `help:"Default confirmation action" default:"true"`
+	Timeout     int          `help:"Timeout for confirmation in seconds" default:"15" env:"GUM_CONFIRM_TIMEOUT"`
+	TimeoutMsg  string       `arg:"" help:"Timeout message" default:"Selecting default options in "`
 	Prompt      string       `arg:"" help:"Prompt to display." default:"Are you sure?"`
 	PromptStyle style.Styles `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
 	//nolint:staticcheck

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -8,7 +8,6 @@ type Options struct {
 	Negative    string       `help:"The title of the negative action" default:"No"`
 	Default     bool         `help:"Default confirmation action" default:"true"`
 	Timeout     int          `help:"Timeout for confirmation in seconds" default:"15" env:"GUM_CONFIRM_TIMEOUT"`
-	TimeoutMsg  string       `arg:"" help:"Timeout message" default:"Selecting default options in "`
 	Prompt      string       `arg:"" help:"Prompt to display." default:"Are you sure?"`
 	PromptStyle style.Styles `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
 	//nolint:staticcheck


### PR DESCRIPTION
Fixes #103 

### Changes
- Change `confirm` to have a default timeout of 15 seconds
- Configurable timeout using `--timeout` argument 
- Added `help` for options that can be used

This merge request is heavily referenced from [demo of bubbletea](https://github.com/charmbracelet/bubbletea/blob/master/examples/views/main.go), where a timer is implemented to count each second

![gum-confirmation-initial](https://user-images.githubusercontent.com/4262799/183241855-d41d2019-97a8-4ff2-9d6d-e46aa6fdb7a3.svg)


