### PR TITLE
fix: disable aur publish

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,7 +17,6 @@ jobs:
       docker_token: ${{ secrets.DOCKERHUB_TOKEN }}
       gh_pat: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       goreleaser_key: ${{ secrets.GORELEASER_KEY }}
-      aur_key: ${{ secrets.AUR_KEY }}
       fury_token: ${{ secrets.FURY_TOKEN }}
       nfpm_gpg_key: ${{ secrets.NFPM_GPG_KEY }}
       nfpm_passphrase: ${{ secrets.NFPM_PASSPHRASE }}


### PR DESCRIPTION
gum-bin was deleted from AUR because it is now on main, so we should not push it again.



https://aur.archlinux.org/packages?O=0&K=gum-bin