### PR TITLE
Additional filter subcommand scripting options

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -58,6 +58,11 @@ func (o Options) Run() error {
 		matches = matchAll(choices)
 	}
 
+	if o.SelectOne && len(matches) == 1 {
+		fmt.Println(matches[0].Str)
+		return nil
+	}
+
 	p := tea.NewProgram(model{
 		choices:        choices,
 		indicator:      o.Indicator,

--- a/filter/options.go
+++ b/filter/options.go
@@ -14,4 +14,5 @@ type Options struct {
 	Width          int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
 	Height         int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
 	Value          string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
+	SelectOne      bool         `help:"Auto select single value lists" default:"false" env:"GUM_FILTER_SELECT_ONE"`
 }


### PR DESCRIPTION
### Changes

This pull request adds three new options for the filter subcommand to handle common scripting scenarios.

- `--query`: Sometimes a script already has some user input, say an argument to the script itself, that would be useful as an initial filter. `--query`, if supplied, performs an initial filter on the model before the first view.
- `--select-one`: When using a dynamic list or maybe when paired with the aforementioned `--query` option the initial filtered model has just one match. In this case skipping the view and using that one match as the subcommand output can reduce user friction.
- `--exit-zero`: An almost-opposite to `--select-one`. If the initial model, either before or after the initial filter by `--query`, has zero matches treat this as an error condition.

I defaulted `--select-one` and `--exit-zero` to false to preserve backwards compatibility, but I really think they should default to true, at least for `--exit-zero` without an initial filter with `--query`. Filtering an empty list is kinda nonsensical to begin with. I can make this change if the maintainers agree.

There is also room for improvement of the help text. I tried to follow the pithiness of the other options but I had trouble explaining the behavior of `--exit-zero` in a short sentence.

```
$ seq 1 100 | gum filter --query 3
> 3
• 3
  39
  38
  37
  36
  35
  34
  33
  32
  31
  30
  93
  83
  73
  63
  53
  43
  23
  13
```

```
$ seq 1 10 | gum filter --select-one --query 3
3
```

```
$ seq 1 10 | gum filter --exit-zero --query 11
empty list
$ echo $?
1
```
