### PR TITLE
add timeout on confirm options & messages

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -17,6 +17,8 @@ func (o Options) Run() error {
 		affirmative:     o.Affirmative,
 		negative:        o.Negative,
 		confirmation:    o.Default,
+		timeout:         o.Timeout,
+		hasTimeout:      o.Timeout > 0,
 		prompt:          o.Prompt,
 		selectedStyle:   o.SelectedStyle.ToLipgloss(),
 		unselectedStyle: o.UnselectedStyle.ToLipgloss(),

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -1,14 +1,19 @@
 package confirm
 
-import "github.com/charmbracelet/gum/style"
+import (
+	"time"
+
+	"github.com/charmbracelet/gum/style"
+)
 
 // Options is the customization options for the confirm command.
 type Options struct {
-	Affirmative string       `help:"The title of the affirmative action" default:"Yes"`
-	Negative    string       `help:"The title of the negative action" default:"No"`
-	Default     bool         `help:"Default confirmation action" default:"true"`
-	Prompt      string       `arg:"" help:"Prompt to display." default:"Are you sure?"`
-	PromptStyle style.Styles `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
+	Affirmative string        `help:"The title of the affirmative action" default:"Yes"`
+	Negative    string        `help:"The title of the negative action" default:"No"`
+	Default     bool          `help:"Default confirmation action" default:"true"`
+	Timeout     time.Duration `help:"Timeout for confirmation" default:"0" env:"GUM_CONFIRM_TIMEOUT"`
+	Prompt      string        `arg:"" help:"Prompt to display." default:"Are you sure?"`
+	PromptStyle style.Styles  `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
 	//nolint:staticcheck
 	SelectedStyle style.Styles `embed:"" prefix:"selected." help:"The style of the selected action" set:"defaultBackground=212" set:"defaultForeground=230" set:"defaultPadding=0 3" set:"defaultMargin=1 1" envprefix:"GUM_CONFIRM_SELECTED_"`
 	//nolint:staticcheck


### PR DESCRIPTION
Fixes #103 
Closes #106 

### Changes
- `--timeout` flag that takes a `time.Duration` for timing out the confirm.