### PR TITLE
docs: fix a warning in the filter-key-value example

### DIFF
--- a/examples/filter-key-value.sh
+++ b/examples/filter-key-value.sh
@@ -4,7 +4,8 @@ export LIST=$(cat <<END
 Cow:Moo
 Cat:Meow
 Dog:Woof
-END)
+END
+)
 
 ANIMAL=$(echo "$LIST" | cut -d':' -f1 | gum filter)
 SOUND=$(echo "$LIST" | grep $ANIMAL | cut -d':' -f2)


### PR DESCRIPTION
### Changes
- Fixing a minor warning ```filter-key-value.sh: line 12: warning: here-document at line 8 delimited by end-of-file (wanted `END')```