### PR TITLE
added nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ testdata
 # Folders
 completions/
 manpages/
+
+# nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660639432,
+        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+    outputs = {self, nixpkgs, ...}:
+    let
+        system="x86_64-linux";
+        pkgs=import nixpkgs {inherit system;};
+    in
+    {
+        packages.${system}.default = pkgs.buildGoModule {
+            name = "gum";
+            src = self;
+            vendorSha256="vvNoO5eABGVwvAzK33uPelmo3BKxfqiYgEXZI7kgeSo=";
+        };
+        
+    };
+
+}


### PR DESCRIPTION
This is a really simple pull request that adds 2 files `flake.nix` and `flake.lock`. This just makes it easier for people using Nix to get the latest version.

I also added a line to the .gitignore that ignores the default output directory (symlink) when building with nix. 

I would only need to update these files if the dependencies change in the `go.mod` file, but I am happy to maintain it.