### PR TITLE
feat(filter): added multiple selections

### DIFF
--- a/choose/options.go
+++ b/choose/options.go
@@ -12,7 +12,7 @@ type Options struct {
 	Cursor            string       `help:"Prefix to show on item that corresponds to the cursor position" default:"> " env:"GUM_CHOOSE_CURSOR"`
 	CursorPrefix      string       `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"[•] " env:"GUM_CHOOSE_CURSOR_PREFIX"`
 	SelectedPrefix    string       `help:"Prefix to show on selected items (hidden if limit is 1)" default:"[✕] " env:"GUM_CHOOSE_SELECTED_PREFIX"`
-	UnselectedPrefix  string       `help:"Prefix to show on selected items (hidden if limit is 1)" default:"[ ] " env:"GUM_CHOOSE_UNSELECTED_PREFIX"`
+	UnselectedPrefix  string       `help:"Prefix to show on unselected items (hidden if limit is 1)" default:"[ ] " env:"GUM_CHOOSE_UNSELECTED_PREFIX"`
 	CursorStyle       style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_CURSOR_"`
 	ItemStyle         style.Styles `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`
 	SelectedItemStyle style.Styles `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_"`

--- a/filter/command.go
+++ b/filter/command.go
@@ -58,16 +58,24 @@ func (o Options) Run() error {
 		matches = matchAll(choices)
 	}
 
+	if o.NoLimit {
+		o.Limit = len(choices)
+	}
+
 	p := tea.NewProgram(model{
-		choices:        choices,
-		indicator:      o.Indicator,
-		matches:        matches,
-		textinput:      i,
-		viewport:       &v,
-		indicatorStyle: o.IndicatorStyle.ToLipgloss(),
-		matchStyle:     o.MatchStyle.ToLipgloss(),
-		textStyle:      o.TextStyle.ToLipgloss(),
-		height:         o.Height,
+		choices:            choices,
+		indicator:          o.Indicator,
+		matches:            matches,
+		textinput:          i,
+		viewport:           &v,
+		indicatorStyle:     o.IndicatorStyle.ToLipgloss(),
+		selectionMarkStyle: o.SelectionMarkStyle.ToLipgloss(),
+		selectionMark:      o.SelectionMark,
+		matchStyle:         o.MatchStyle.ToLipgloss(),
+		textStyle:          o.TextStyle.ToLipgloss(),
+		height:             o.Height,
+		multiSelection:     make(map[string]interface{}),
+		limit:              o.Limit,
 	}, options...)
 
 	tm, err := p.StartReturningModel()
@@ -79,7 +87,14 @@ func (o Options) Run() error {
 	if m.aborted {
 		return exit.ErrAborted
 	}
-	if len(m.matches) > m.selected && m.selected >= 0 {
+
+	// allSelections contains values only if --no-limit is passed,
+	// hence there is no need to check if the option is enabled
+	if len(m.multiSelection) > 0 {
+		for k := range m.multiSelection {
+			fmt.Println(k)
+		}
+	} else if len(m.matches) > m.selected && m.selected >= 0 {
 		fmt.Println(m.matches[m.selected].Str)
 	}
 

--- a/filter/command.go
+++ b/filter/command.go
@@ -88,8 +88,9 @@ func (o Options) Run() error {
 		return exit.ErrAborted
 	}
 
-	// allSelections contains values only if --no-limit is passed,
-	// hence there is no need to check if the option is enabled
+	// allSelections contains values only if limit is greater
+	// than 1 or if flag --no-limit is passed, hence there is
+	// no need to further checks
 	if len(m.multiSelection) > 0 {
 		for k := range m.multiSelection {
 			fmt.Println(k)

--- a/filter/command.go
+++ b/filter/command.go
@@ -63,19 +63,19 @@ func (o Options) Run() error {
 	}
 
 	p := tea.NewProgram(model{
-		choices:            choices,
-		indicator:          o.Indicator,
-		matches:            matches,
-		textinput:          i,
-		viewport:           &v,
-		indicatorStyle:     o.IndicatorStyle.ToLipgloss(),
-		selectionMarkStyle: o.SelectionMarkStyle.ToLipgloss(),
-		selectionMark:      o.SelectionMark,
-		matchStyle:         o.MatchStyle.ToLipgloss(),
-		textStyle:          o.TextStyle.ToLipgloss(),
-		height:             o.Height,
-		multiSelection:     make(map[string]interface{}),
-		limit:              o.Limit,
+		choices:                choices,
+		indicator:              o.Indicator,
+		matches:                matches,
+		textinput:              i,
+		viewport:               &v,
+		indicatorStyle:         o.IndicatorStyle.ToLipgloss(),
+		selectedIndicatorStyle: o.SelectedIndicatorStyle.ToLipgloss(),
+		selectedIndicator:      o.SelectedIndicator,
+		matchStyle:             o.MatchStyle.ToLipgloss(),
+		textStyle:              o.TextStyle.ToLipgloss(),
+		height:                 o.Height,
+		multiSelection:         make(map[string]interface{}),
+		limit:                  o.Limit,
 	}, options...)
 
 	tm, err := p.StartReturningModel()
@@ -95,8 +95,8 @@ func (o Options) Run() error {
 		for k := range m.multiSelection {
 			fmt.Println(k)
 		}
-	} else if len(m.matches) > m.selected && m.selected >= 0 {
-		fmt.Println(m.matches[m.selected].Str)
+	} else if len(m.matches) > m.cursor && m.cursor >= 0 {
+		fmt.Println(m.matches[m.cursor].Str)
 	}
 
 	return nil

--- a/filter/command.go
+++ b/filter/command.go
@@ -63,19 +63,21 @@ func (o Options) Run() error {
 	}
 
 	p := tea.NewProgram(model{
-		choices:                choices,
-		indicator:              o.Indicator,
-		matches:                matches,
-		textinput:              i,
-		viewport:               &v,
-		indicatorStyle:         o.IndicatorStyle.ToLipgloss(),
-		selectedIndicatorStyle: o.SelectedIndicatorStyle.ToLipgloss(),
-		selectedIndicator:      o.SelectedIndicator,
-		matchStyle:             o.MatchStyle.ToLipgloss(),
-		textStyle:              o.TextStyle.ToLipgloss(),
-		height:                 o.Height,
-		multiSelection:         make(map[string]struct{}),
-		limit:                  o.Limit,
+		choices:               choices,
+		indicator:             o.Indicator,
+		matches:               matches,
+		textinput:             i,
+		viewport:              &v,
+		indicatorStyle:        o.IndicatorStyle.ToLipgloss(),
+		selectedPrefixStyle:   o.SelectedPrefixStyle.ToLipgloss(),
+		selectedPrefix:        o.SelectedPrefix,
+		unselectedPrefixStyle: o.UnselectedPrefixStyle.ToLipgloss(),
+		unselectedPrefix:      o.UnselectedPrefix,
+		matchStyle:            o.MatchStyle.ToLipgloss(),
+		textStyle:             o.TextStyle.ToLipgloss(),
+		height:                o.Height,
+		selected:              make(map[string]struct{}),
+		limit:                 o.Limit,
 	}, options...)
 
 	tm, err := p.StartReturningModel()
@@ -91,8 +93,8 @@ func (o Options) Run() error {
 	// allSelections contains values only if limit is greater
 	// than 1 or if flag --no-limit is passed, hence there is
 	// no need to further checks
-	if len(m.multiSelection) > 0 {
-		for k := range m.multiSelection {
+	if len(m.selected) > 0 {
+		for k := range m.selected {
 			fmt.Println(k)
 		}
 	} else if len(m.matches) > m.cursor && m.cursor >= 0 {

--- a/filter/command.go
+++ b/filter/command.go
@@ -74,7 +74,7 @@ func (o Options) Run() error {
 		matchStyle:             o.MatchStyle.ToLipgloss(),
 		textStyle:              o.TextStyle.ToLipgloss(),
 		height:                 o.Height,
-		multiSelection:         make(map[string]interface{}),
+		multiSelection:         make(map[string]struct{}),
 		limit:                  o.Limit,
 	}, options...)
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -27,7 +27,7 @@ type model struct {
 	choices                []string
 	matches                []fuzzy.Match
 	cursor                 int
-	multiSelection         map[string]interface{}
+	multiSelection         map[string]struct{}
 	limit                  int
 	numSelected            int
 	indicator              string
@@ -133,7 +133,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				delete(m.multiSelection, m.matches[m.cursor].Str)
 				m.numSelected--
 			} else if m.numSelected < m.limit {
-				m.multiSelection[m.matches[m.cursor].Str] = nil
+				m.multiSelection[m.matches[m.cursor].Str] = struct{}{}
 				m.numSelected++
 			}
 

--- a/filter/options.go
+++ b/filter/options.go
@@ -4,18 +4,18 @@ import "github.com/charmbracelet/gum/style"
 
 // Options is the customization options for the filter command.
 type Options struct {
-	Indicator          string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
-	IndicatorStyle     style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
-	Limit              int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
-	NoLimit            bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
-	SelectionMark      string       `help:"Character for selection marks" default:">" env:"GUM_FILTER_SELECTED"`
-	SelectionMarkStyle style.Styles `embed:"" prefix:"selection-mark." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_"`
-	TextStyle          style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
-	MatchStyle         style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
-	Placeholder        string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
-	Prompt             string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
-	PromptStyle        style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
-	Width              int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
-	Height             int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
-	Value              string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
+	Indicator              string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
+	IndicatorStyle         style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
+	Limit                  int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
+	NoLimit                bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	SelectedIndicator      string       `help:"Character to indicate selected items" default:">" env:"GUM_FILTER_SELECTED_INDICATOR"`
+	SelectedIndicatorStyle style.Styles `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_INDICATOR_"`
+	TextStyle              style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
+	MatchStyle             style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
+	Placeholder            string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
+	Prompt                 string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
+	PromptStyle            style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
+	Width                  int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
+	Height                 int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
+	Value                  string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
 }

--- a/filter/options.go
+++ b/filter/options.go
@@ -4,18 +4,20 @@ import "github.com/charmbracelet/gum/style"
 
 // Options is the customization options for the filter command.
 type Options struct {
-	Indicator              string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
-	IndicatorStyle         style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
-	Limit                  int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
-	NoLimit                bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
-	SelectedIndicator      string       `help:"Character to indicate selected items" default:">" env:"GUM_FILTER_SELECTED_INDICATOR"`
-	SelectedIndicatorStyle style.Styles `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_INDICATOR_"`
-	TextStyle              style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
-	MatchStyle             style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
-	Placeholder            string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
-	Prompt                 string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
-	PromptStyle            style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
-	Width                  int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
-	Height                 int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
-	Value                  string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
+	Indicator             string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
+	IndicatorStyle        style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
+	Limit                 int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
+	NoLimit               bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	SelectedPrefix        string       `help:"Character to indicate selected items (hidden if limit is 1)" default:" ◉ " env:"GUM_FILTER_SELECTED_PREFIX"`
+	SelectedPrefixStyle   style.Styles `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_PREFIX_"`
+	UnselectedPrefix      string       `help:"Character to indicate unselected items (hidden if limit is 1)" default:" ○ " env:"GUM_FILTER_UNSELECTED_PREFIX"`
+	UnselectedPrefixStyle style.Styles `embed:"" prefix:"unselected-prefix." set:"defaultForeground=240" envprefix:"GUM_FILTER_UNSELECTED_PREFIX_"`
+	TextStyle             style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
+	MatchStyle            style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
+	Placeholder           string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
+	Prompt                string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
+	PromptStyle           style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
+	Width                 int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
+	Height                int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
+	Value                 string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
 }

--- a/filter/options.go
+++ b/filter/options.go
@@ -4,14 +4,18 @@ import "github.com/charmbracelet/gum/style"
 
 // Options is the customization options for the filter command.
 type Options struct {
-	Indicator      string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
-	IndicatorStyle style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
-	TextStyle      style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
-	MatchStyle     style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
-	Placeholder    string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
-	Prompt         string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
-	PromptStyle    style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
-	Width          int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
-	Height         int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
-	Value          string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
+	Indicator          string       `help:"Character for selection" default:"•" env:"GUM_FILTER_INDICATOR"`
+	IndicatorStyle     style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
+	Limit              int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
+	NoLimit            bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	SelectionMark      string       `help:"Character for selection marks" default:">" env:"GUM_FILTER_SELECTED"`
+	SelectionMarkStyle style.Styles `embed:"" prefix:"selection-mark." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_"`
+	TextStyle          style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
+	MatchStyle         style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
+	Placeholder        string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
+	Prompt             string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`
+	PromptStyle        style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILTER_PROMPT_"`
+	Width              int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
+	Height             int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
+	Value              string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
 }


### PR DESCRIPTION
fix #25

This PR adds the support to multiple selections in `filter` command, more or less like it already happens in `choose`.
When more than one selection is allowed, it is possible to mark/unmark a given number of items by pressing `tab`.
If the number of allowed selections is 1, there is no need to first mark the selection, pressing enter will directly print the selection under the cursor (again, like in `choose`).


 ### Changes
- introduction of flags/Options similar to what is offered by `choose`:
  - `--limit`: set the number of allowed selections (default to 1)
  - `--no-limit`: allows any number of selections, overriding limit
  - `--selected-prefix`: character(s) that mark selected items
  - `--selected-prefix.foreground`: style for the component mentioned above
  - `--unselected-prefix`: character(s) that mark selected items
  - `--unselected-prefix.foreground`: style for the component mentioned above
- introduction of new fields in model struct:
  - `selectedPrefix` and `selectedPrefixStyle`, character(s) and style of selected items, respectively
  - `unselectedPrefix` and `unselectedPrefixStyle`, character(s) and style of unselected items, respectively
  - `limit` and `numSelected` (used with the same purpose found in `choose`)
  - `selected` is the map of currently selected items


I hope the code quality and style is in line with the awesome projects you guys offer. In case anything is wrong I'll happily fix it ASAP.