### PR TITLE
fix(choose): wrong "a" behavior

### DIFF
--- a/choose/choose.go
+++ b/choose/choose.go
@@ -89,9 +89,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 			for i := range m.items {
+				if m.numSelected >= m.limit {
+					break // do not exceed given limit
+				}
+				if m.items[i].selected {
+					continue
+				}
 				m.items[i].selected = true
+				m.numSelected++
 			}
-			m.numSelected = len(m.items)
 		case "A":
 			if m.limit <= 1 {
 				break


### PR DESCRIPTION
Fixes #135 

### Changes
- when pressing "a", it actually checks the number of left selections based on the limit, as opposed to select all items in the list
