### PR TITLE
feat(choose): add optional flag

### DIFF
--- a/choose/choose.go
+++ b/choose/choose.go
@@ -29,6 +29,7 @@ type model struct {
 	quitting         bool
 	index            int
 	limit            int
+	optional         bool
 	numSelected      int
 	paginator        paginator.Model
 	aborted          bool
@@ -124,10 +125,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "enter":
 			m.quitting = true
-			// If the user hasn't selected any items in a multi-select.
-			// Then we select the item that they have pressed enter on. If they
-			// have selected items, then we simply return them.
-			if m.numSelected < 1 {
+			// If the user hasn't selected any items in a multi-select,
+			// then we select the item that they have pressed enter on,
+			// except if --optional flag is enabled.
+			// If they have selected items, then we simply return them.
+			if m.numSelected < 1 && !m.optional {
 				m.items[m.index].selected = true
 			}
 			return m, tea.Quit

--- a/choose/command.go
+++ b/choose/command.go
@@ -74,6 +74,7 @@ func (o Options) Run() error {
 		cursorPrefix:      o.CursorPrefix,
 		items:             items,
 		limit:             o.Limit,
+		optional:          o.Optional,
 		paginator:         pager,
 		cursorStyle:       o.CursorStyle.ToLipgloss(),
 		itemStyle:         o.ItemStyle.ToLipgloss(),
@@ -98,7 +99,7 @@ func (o Options) Run() error {
 		}
 	}
 
-	fmt.Println(strings.TrimSuffix(s.String(), "\n"))
+	fmt.Print(s.String())
 
 	return nil
 }

--- a/choose/options.go
+++ b/choose/options.go
@@ -8,6 +8,7 @@ type Options struct {
 
 	Limit             int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit           bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	Optional          bool         `help:"Do not force highlighted option if none is selected" group:"Selection"`
 	Height            int          `help:"Height of the list" default:"10" env:"GUM_CHOOSE_HEIGHT"`
 	Cursor            string       `help:"Prefix to show on item that corresponds to the cursor position" default:"> " env:"GUM_CHOOSE_CURSOR"`
 	CursorPrefix      string       `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"[•] " env:"GUM_CHOOSE_CURSOR_PREFIX"`


### PR DESCRIPTION
Fixes #87 

### Changes
- added `--optional` flag so that without explicitly options selected, `enter` doesn't select highlighted entry
