### PR TITLE
docs: fix `write` key description

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ gum input --password > password.text
 
 Prompt for some multi-line text.
 
-Note: `CTRL+D` is used to complete text entry. `CTRL+C` and `esc` will cancel.
+Note: `CTRL+D` and `esc` are used to complete text entry. `CTRL+C` will cancel.
 
 ```bash
 gum write > story.text


### PR DESCRIPTION
I found a description of `gum write` in README that differs from the implementation, so I propose a correction.

https://github.com/charmbracelet/gum/blob/5993a7b4907562d004546561852e7674c7e6d220/write/write.go#L33-L40

↓README
```
`CTRL+D` is used to complete text entry. `CTRL+C` and `esc` will cancel.
```

### Changes
- [README.md `write`](https://github.com/charmbracelet/gum/tree/5993a7b4907562d004546561852e7674c7e6d220#write)

