### PR TITLE
fix(format): do not append additional new line

### DIFF
--- a/format/command.go
+++ b/format/command.go
@@ -41,6 +41,6 @@ func (o Options) Run() error {
 		return err
 	}
 
-	fmt.Println(v)
+	fmt.Print(v)
 	return nil
 }


### PR DESCRIPTION
Fixes #146 

### Changes
- replaced `fmt.Println` with `fmt.Print`, as discussed in #146 
