### PR TITLE
fix(prompt): fix default selection of prompt, timer and exit code

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -14,15 +14,16 @@ import (
 // action with an affirmative or negative answer.
 func (o Options) Run() error {
 	m, err := tea.NewProgram(model{
-		affirmative:     o.Affirmative,
-		negative:        o.Negative,
-		confirmation:    o.Default,
-		timeout:         o.Timeout,
-		hasTimeout:      o.Timeout > 0,
-		prompt:          o.Prompt,
-		selectedStyle:   o.SelectedStyle.ToLipgloss(),
-		unselectedStyle: o.UnselectedStyle.ToLipgloss(),
-		promptStyle:     o.PromptStyle.ToLipgloss(),
+		affirmative:      o.Affirmative,
+		negative:         o.Negative,
+		confirmation:     o.Default,
+		defaultSelection: o.Default,
+		timeout:          o.Timeout,
+		hasTimeout:       o.Timeout > 0,
+		prompt:           o.Prompt,
+		selectedStyle:    o.SelectedStyle.ToLipgloss(),
+		unselectedStyle:  o.UnselectedStyle.ToLipgloss(),
+		promptStyle:      o.PromptStyle.ToLipgloss(),
 	}, tea.WithOutput(os.Stderr)).Run()
 
 	if err != nil {

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -29,6 +29,8 @@ type model struct {
 
 	confirmation bool
 
+	defaultSelection bool
+
 	// styles
 	promptStyle     lipgloss.Style
 	selectedStyle   lipgloss.Style
@@ -49,6 +51,7 @@ func (m model) Init() tea.Cmd {
 	if m.timeout > 0 {
 		return tick()
 	}
+	m.defaultSelection = m.confirmation
 	return nil
 }
 
@@ -99,18 +102,27 @@ func (m model) View() string {
 		return ""
 	}
 
-	var aff, neg, timeout string
+	var aff, neg, timeout, affirmativeTimeout, negativeTimeout string
 
 	if m.hasTimeout {
 		timeout = fmt.Sprintf(" (%d)", max(0, int(m.timeout.Seconds())))
 	}
 
-	if m.confirmation {
-		aff = m.selectedStyle.Render(m.affirmative + timeout)
-		neg = m.unselectedStyle.Render(m.negative)
+	// set timer based on defaultSelection
+	if m.defaultSelection {
+		affirmativeTimeout = m.affirmative + timeout
+		negativeTimeout = m.negative
 	} else {
-		aff = m.unselectedStyle.Render(m.affirmative)
-		neg = m.selectedStyle.Render(m.negative + timeout)
+		affirmativeTimeout = m.affirmative
+		negativeTimeout = m.negative + timeout
+	}
+
+	if m.confirmation {
+		aff = m.selectedStyle.Render(affirmativeTimeout)
+		neg = m.unselectedStyle.Render(negativeTimeout)
+	} else {
+		aff = m.unselectedStyle.Render(affirmativeTimeout)
+		neg = m.selectedStyle.Render(negativeTimeout)
 	}
 
 	// If the option is intentionally empty, do not show it.

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -86,7 +86,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		if m.timeout <= 0 {
 			m.quitting = true
-			//m.confirmation = false
 			return m, tea.Quit
 		}
 		m.timeout -= tickInterval

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -88,6 +88,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		if m.timeout <= 0 {
 			m.quitting = true
+			m.confirmation = m.defaultSelection
 			return m, tea.Quit
 		}
 		m.timeout -= tickInterval

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -51,7 +51,6 @@ func (m model) Init() tea.Cmd {
 	if m.timeout > 0 {
 		return tick()
 	}
-	m.defaultSelection = m.confirmation
 	return nil
 }
 

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -86,7 +86,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		if m.timeout <= 0 {
 			m.quitting = true
-			m.confirmation = false
+			//m.confirmation = false
 			return m, tea.Quit
 		}
 		m.timeout -= tickInterval
@@ -107,8 +107,8 @@ func (m model) View() string {
 	}
 
 	if m.confirmation {
-		aff = m.selectedStyle.Render(m.affirmative)
-		neg = m.unselectedStyle.Render(m.negative + timeout)
+		aff = m.selectedStyle.Render(m.affirmative + timeout)
+		neg = m.unselectedStyle.Render(m.negative)
 	} else {
 		aff = m.unselectedStyle.Render(m.affirmative)
 		neg = m.selectedStyle.Render(m.negative + timeout)


### PR DESCRIPTION
Fixes #142 

### Changes
- Change timeout to show on correct prompt (not only on `exit code 1`)
- Fix timeout to not enforce user options to `exit code 1`

Demo for 3 commands:
- [x] `❯ ./gum confirm --timeout 3s --default=true "delete"` -> should return `exit code 0` and default to `yes`
- [x] `❯ ./gum confirm --timeout 3s --default=false "delete"` -> should return `exit code 1` and default to `no` 
- [x] `❯ ./gum confirm --timeout 3s "delete"` -> should return `exit code 0` and default to `yes`
![gum-confirm-timeout-fix](https://user-images.githubusercontent.com/4262799/189463283-460d1a26-0755-4b0b-b3aa-92da66313af4.gif)

