### PR TITLE
Updates hash and adds overlay to flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,7 @@
+{ pkgs }:
+
+pkgs.buildGoModule {
+  name = "gum";
+  src = ./.;
+  vendorSha256="rMqhYZMa0+5F3X4WDm4jE6IwlzOugqm65SAP38bdQx8=";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,39 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
       "locked": {
-        "lastModified": 1660639432,
-        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1664107978,
+        "narHash": "sha256-31I9XnIjXkUa62BM1Zr/ylKMf9eVO5PtoX2mGpmB7/U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "72783a2d0dbbf030bff1537873dd5b85b3fb332f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,19 @@
 {
-    outputs = {self, nixpkgs, ...}:
-    let
-        system="x86_64-linux";
-        pkgs=import nixpkgs {inherit system;};
-    in
-    {
-        packages.${system}.default = pkgs.buildGoModule {
-            name = "gum";
-            src = self;
-            vendorSha256="vvNoO5eABGVwvAzK33uPelmo3BKxfqiYgEXZI7kgeSo=";
-        };
-        
-    };
+  description = "A tool for glamorous shell scripts";
 
+  inputs = {
+    nixpkgs.url = github:nixos/nixpkgs/nixos-22.05;
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; }; in
+      rec {
+        packages.default = import ./default.nix { inherit pkgs; };
+      }) // {
+        overlays.default = final: prev: { 
+          gum = import ./default.nix { pkgs = final; };
+        };
+      };
 }


### PR DESCRIPTION
Fixes #...

The hash was out of date in the nix flake. I went to update it and went ahead and made some other basic improvements in the flake.

1. [flake-utils](https://github.com/numtide/flake-utils) is a commonly used nix library which makes it easier to build flakes which target all the default systems supported by Hydra. 

2. Adding an Overlay allows nix users to more quickly merge `gum` into their local nixpkgs. 

### Changes
- Updates the vendor hash in the Nix Flake
- Uses flake-utils to support more systems in Nix
- Adds a NIx overlay.
