### PR TITLE
feat: add location to spin

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -22,6 +22,7 @@ func (o Options) Run() error {
 		spinner: s,
 		title:   o.TitleStyle.ToLipgloss().Render(o.Title),
 		command: o.Command,
+		align:   o.Align,
 	}
 	p := tea.NewProgram(m, tea.WithOutput(os.Stderr))
 	mm, err := p.StartReturningModel()

--- a/spin/options.go
+++ b/spin/options.go
@@ -11,4 +11,5 @@ type Options struct {
 	SpinnerStyle style.Styles `embed:"" prefix:"spinner." set:"defaultForeground=212" envprefix:"GUM_SPIN_SPINNER_"`
 	Title        string       `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`
 	TitleStyle   style.Styles `embed:"" prefix:"title." envprefix:"GUM_SPIN_TITLE_"`
+	Align        string       `help:"Alignment of spinner with regard to the title" short:"a" type:"align" enum:"left,right" default:"left" env:"GUM_SPIN_ALIGN"`
 }

--- a/spin/spin.go
+++ b/spin/spin.go
@@ -25,6 +25,7 @@ import (
 type model struct {
 	spinner spinner.Model
 	title   string
+	align   string
 	command []string
 	aborted bool
 
@@ -73,7 +74,13 @@ func (m model) Init() tea.Cmd {
 		commandStart(m.command),
 	)
 }
-func (m model) View() string { return m.spinner.View() + " " + m.title }
+func (m model) View() string {
+	if m.align == "left" {
+		return m.spinner.View() + " " + m.title
+	}
+
+	return m.title + " " + m.spinner.View()
+}
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd


### PR DESCRIPTION
Sometimes it is nice to spin to the right side of the title, not the left, so add a --location option to pick the left or right side.  The default remains "left".

New option is:
	--location="left|right"
and the environment variable GUM_SPIN_LOCATION can also be used.