### PR TITLE
feat(spin): read and set the title from the stdout of the executing program

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -23,6 +23,7 @@ func (o Options) Run() error {
 		title:   o.TitleStyle.ToLipgloss().Render(o.Title),
 		command: o.Command,
 		align:   o.Align,
+		stdin:   make(chan string),
 	}
 	p := tea.NewProgram(m, tea.WithOutput(os.Stderr))
 	mm, err := p.StartReturningModel()

--- a/spin/command.go
+++ b/spin/command.go
@@ -23,7 +23,10 @@ func (o Options) Run() error {
 		title:   o.TitleStyle.ToLipgloss().Render(o.Title),
 		command: o.Command,
 		align:   o.Align,
-		stdin:   make(chan string),
+	}
+	if o.TitleFromStdout {
+		m.readFromStdin = true
+		m.stdin = make(chan string)
 	}
 	p := tea.NewProgram(m, tea.WithOutput(os.Stderr))
 	mm, err := p.StartReturningModel()

--- a/spin/options.go
+++ b/spin/options.go
@@ -6,10 +6,11 @@ import "github.com/charmbracelet/gum/style"
 type Options struct {
 	Command []string `arg:"" help:"Command to run"`
 
-	ShowOutput   bool         `help:"Show output of command" default:"false" env:"GUM_SPIN_SHOW_OUTPUT"`
-	Spinner      string       `help:"Spinner type" short:"s" type:"spinner" enum:"line,dot,minidot,jump,pulse,points,globe,moon,monkey,meter,hamburger" default:"dot" env:"GUM_SPIN_SPINNER"`
-	SpinnerStyle style.Styles `embed:"" prefix:"spinner." set:"defaultForeground=212" envprefix:"GUM_SPIN_SPINNER_"`
-	Title        string       `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`
-	TitleStyle   style.Styles `embed:"" prefix:"title." envprefix:"GUM_SPIN_TITLE_"`
-	Align        string       `help:"Alignment of spinner with regard to the title" short:"a" type:"align" enum:"left,right" default:"left" env:"GUM_SPIN_ALIGN"`
+	ShowOutput      bool         `help:"Show output of command" default:"false" env:"GUM_SPIN_SHOW_OUTPUT"`
+	Spinner         string       `help:"Spinner type" short:"s" type:"spinner" enum:"line,dot,minidot,jump,pulse,points,globe,moon,monkey,meter,hamburger" default:"dot" env:"GUM_SPIN_SPINNER"`
+	SpinnerStyle    style.Styles `embed:"" prefix:"spinner." set:"defaultForeground=212" envprefix:"GUM_SPIN_SPINNER_"`
+	Title           string       `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`
+	TitleStyle      style.Styles `embed:"" prefix:"title." envprefix:"GUM_SPIN_TITLE_"`
+	Align           string       `help:"Alignment of spinner with regard to the title" short:"a" type:"align" enum:"left,right" default:"left" env:"GUM_SPIN_ALIGN"`
+	TitleFromStdout bool         `help:"Read and update title from the stdout of executing program" default:"false" env:"GUM_TITLE_FROM_STDOUT"`
 }

--- a/spin/options.go
+++ b/spin/options.go
@@ -12,4 +12,5 @@ type Options struct {
 	Title        string       `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`
 	TitleStyle   style.Styles `embed:"" prefix:"title." envprefix:"GUM_SPIN_TITLE_"`
 	Align        string       `help:"Alignment of spinner with regard to the title" short:"a" type:"align" enum:"left,right" default:"left" env:"GUM_SPIN_ALIGN"`
+	// ReadFromString bool         `help:"Read and display title from stdin" default:"false" envprefix:"GUM_SPIN_TITLE_FROM_STDIN`
 }

--- a/spin/options.go
+++ b/spin/options.go
@@ -12,5 +12,4 @@ type Options struct {
 	Title        string       `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`
 	TitleStyle   style.Styles `embed:"" prefix:"title." envprefix:"GUM_SPIN_TITLE_"`
 	Align        string       `help:"Alignment of spinner with regard to the title" short:"a" type:"align" enum:"left,right" default:"left" env:"GUM_SPIN_ALIGN"`
-	// ReadFromString bool         `help:"Read and display title from stdin" default:"false" envprefix:"GUM_SPIN_TITLE_FROM_STDIN`
 }


### PR DESCRIPTION
Fixes #157 

### Changes
- `gum spin`: Read title from the stdout of the executing program and set it as the title of spinner

### Demo

loop.sh
```bash
#!/bin/bash
AR=('watching' 'updating' 'waiting')
i=0
count_of_elements=${#AR[@]}
while true; do
printf "${AR[$i]}\n" #dispay result
i=$((i+1))
sleep 4
if [ $i -gt 2 ]; then
    exit 0
fi
done
```

```bash
chmod +x loop.sh
go run . spin --title "hello" --title-from-stdout -- ./loop.sh
```

https://user-images.githubusercontent.com/25000090/193649385-d65a981e-4e9d-4f95-a487-f33771bfe76d.mov

