### PR TITLE
fix(confirm): an empty --negative will not be displayed

### DIFF
--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -103,6 +103,11 @@ func (m model) View() string {
 		neg = m.selectedStyle.Render(m.negative + timeout)
 	}
 
+	// If the option is intentionally empty, do not show it.
+	if m.negative == "" {
+		neg = ""
+	}
+
 	return lipgloss.JoinVertical(lipgloss.Center, m.promptStyle.Render(m.prompt), lipgloss.JoinHorizontal(lipgloss.Left, aff, neg))
 }
 

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -63,6 +63,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "left", "h", "ctrl+p", "tab",
 			"right", "l", "ctrl+n", "shift+tab":
+			if m.negative == "" {
+				break
+			}
 			m.confirmation = !m.confirmation
 		case "enter":
 			m.quitting = true


### PR DESCRIPTION
This change will hide the normally "No" button when the text is empty. In most cases, this will serve as an acknowledgement and the affirmative message would likely change.

This seems to be better than displaying an empty button.

Resolves #145
