### PR TITLE
feat(filter): add reverse layout

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -78,6 +78,7 @@ func (o Options) Run() error {
 		height:                o.Height,
 		selected:              make(map[string]struct{}),
 		limit:                 o.Limit,
+		reverse:               o.Reverse,
 	}, options...)
 
 	tm, err := p.StartReturningModel()

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -115,9 +115,8 @@ func (m model) View() string {
 	// View the input and the filtered choices
 	if m.reverse {
 		return m.viewport.View() + "\n" + m.textinput.View()
-	} else {
-		return m.textinput.View() + "\n" + m.viewport.View()
 	}
+	return m.textinput.View() + "\n" + m.viewport.View()
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -41,6 +41,7 @@ type model struct {
 	indicatorStyle        lipgloss.Style
 	selectedPrefixStyle   lipgloss.Style
 	unselectedPrefixStyle lipgloss.Style
+	reverse               bool
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -51,9 +52,23 @@ func (m model) View() string {
 
 	var s strings.Builder
 
+	// For reverse layout, if the number of matches is less than the viewport
+	// height, we need to offset the matches so that the first match is at the
+	// bottom edge of the viewport instead of in the middle.
+	if m.reverse && len(m.matches) < m.viewport.Height {
+		s.WriteString(strings.Repeat("\n", m.viewport.Height-len(m.matches)))
+	}
+
 	// Since there are matches, display them so that the user can see, in real
 	// time, what they are searching for.
-	for i, match := range m.matches {
+	last := len(m.matches) - 1
+	for i := range m.matches {
+		// For reverse layout, the matches are displayed in reverse order.
+		if m.reverse {
+			i = last - i
+		}
+		match := m.matches[i]
+
 		// If this is the current selected index, we add a small indicator to
 		// represent it. Otherwise, simply pad the string.
 		if i == m.cursor {
@@ -74,7 +89,7 @@ func (m model) View() string {
 		// For this match, there are a certain number of characters that have
 		// caused the match. i.e. fuzzy matching.
 		// We should indicate to the users which characters are being matched.
-		var mi = 0
+		mi := 0
 		for ci, c := range match.Str {
 			// Check if the current character index matches the current matched
 			// index. If so, color the character to indicate a match.
@@ -98,7 +113,11 @@ func (m model) View() string {
 	m.viewport.SetContent(s.String())
 
 	// View the input and the filtered choices
-	return m.textinput.View() + "\n" + m.viewport.View()
+	if m.reverse {
+		return m.viewport.View() + "\n" + m.textinput.View()
+	} else {
+		return m.textinput.View() + "\n" + m.viewport.View()
+	}
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -109,6 +128,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewport.Height = msg.Height - lipgloss.Height(m.textinput.View())
 		}
 		m.viewport.Width = msg.Width
+		if m.reverse {
+			m.viewport.YOffset = clamp(0, len(m.matches), len(m.matches)-m.viewport.Height)
+		}
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "esc":
@@ -148,6 +170,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.textinput.Value() == "" {
 				m.matches = matchAll(m.choices)
 			}
+
+			// For reverse layout, we need to offset the viewport so that the
+			// visible lines are at the bottom of the viewport.
+			if m.reverse {
+				m.viewport.YOffset = clamp(0, len(m.matches), len(m.matches)-m.viewport.Height)
+			}
 		}
 	}
 
@@ -158,16 +186,30 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *model) CursorUp() {
-	m.cursor = clamp(0, len(m.matches)-1, m.cursor-1)
-	if m.cursor < m.viewport.YOffset {
-		m.viewport.SetYOffset(m.cursor)
+	if m.reverse {
+		m.cursor = clamp(0, len(m.matches)-1, m.cursor+1)
+		if len(m.matches)-m.cursor <= m.viewport.YOffset {
+			m.viewport.SetYOffset(len(m.matches) - m.cursor - 1)
+		}
+	} else {
+		m.cursor = clamp(0, len(m.matches)-1, m.cursor-1)
+		if m.cursor < m.viewport.YOffset {
+			m.viewport.SetYOffset(m.cursor)
+		}
 	}
 }
 
 func (m *model) CursorDown() {
-	m.cursor = clamp(0, len(m.matches)-1, m.cursor+1)
-	if m.cursor >= m.viewport.YOffset+m.viewport.Height {
-		m.viewport.LineDown(1)
+	if m.reverse {
+		m.cursor = clamp(0, len(m.matches)-1, m.cursor-1)
+		if len(m.matches)-m.cursor > m.viewport.Height+m.viewport.YOffset {
+			m.viewport.LineDown(1)
+		}
+	} else {
+		m.cursor = clamp(0, len(m.matches)-1, m.cursor+1)
+		if m.cursor >= m.viewport.YOffset+m.viewport.Height {
+			m.viewport.LineDown(1)
+		}
 	}
 }
 
@@ -182,7 +224,7 @@ func (m *model) ToggleSelection() {
 }
 
 func matchAll(options []string) []fuzzy.Match {
-	var matches = make([]fuzzy.Match, len(options))
+	matches := make([]fuzzy.Match, len(options))
 	for i, option := range options {
 		matches[i] = fuzzy.Match{Str: option}
 	}

--- a/filter/options.go
+++ b/filter/options.go
@@ -20,4 +20,5 @@ type Options struct {
 	Width                 int          `help:"Input width" default:"20" env:"GUM_FILTER_WIDTH"`
 	Height                int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
 	Value                 string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
+	Reverse               bool         `help:"Display from the bottom of the screen" env:"GUM_FILTER_REVERSE"`
 }


### PR DESCRIPTION
resolves: #114 

### Changes

Add `--reverse` flag to `gum filter` command to display the list in reverse direction similar to the default layout for `fzf`

![filter_reverse](https://user-images.githubusercontent.com/67177269/194330679-690880d8-7773-4161-a72f-6da88db80d8c.svg)

