### PR TITLE
fix(choose): error if selected options > limit

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -46,6 +46,10 @@ func (o Options) Run() error {
 		o.Limit = len(o.Options)
 	}
 
+	if len(o.Selected) > o.Limit {
+		return errors.New("number of selected options cannot be greater than the limit")
+	}
+
 	// Keep track of the selected items.
 	currentSelected := 0
 	// Check if selected items should be used.


### PR DESCRIPTION
**Rationale:** If the number of selected options in `--selected` flag is greater than the limit, the last `n` options are selected where `n` is the limit.

Fixes #...

### Changes

Throw an error if the number of selected options are greater than the specified limit
