### PR TITLE
feat(choose): keep order of selected items

### DIFF
--- a/choose/choose.go
+++ b/choose/choose.go
@@ -30,6 +30,7 @@ type model struct {
 	index            int
 	limit            int
 	numSelected      int
+	currentOrder     int
 	paginator        paginator.Model
 	aborted          bool
 
@@ -42,6 +43,7 @@ type model struct {
 type item struct {
 	text     string
 	selected bool
+	order    int
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -96,7 +98,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					continue
 				}
 				m.items[i].selected = true
+				m.items[i].order = m.currentOrder
 				m.numSelected++
+				m.currentOrder++
 			}
 		case "A":
 			if m.limit <= 1 {
@@ -104,8 +108,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			for i := range m.items {
 				m.items[i].selected = false
+				m.items[i].order = 0
 			}
 			m.numSelected = 0
+			m.currentOrder = 0
 		case "ctrl+c", "esc":
 			m.aborted = true
 			m.quitting = true
@@ -120,7 +126,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.numSelected--
 			} else if m.numSelected < m.limit {
 				m.items[m.index].selected = true
+				m.items[m.index].order = m.currentOrder
 				m.numSelected++
+				m.currentOrder++
 			}
 		case "enter":
 			m.quitting = true

--- a/choose/command.go
+++ b/choose/command.go
@@ -123,7 +123,7 @@ func (o Options) Run() error {
 		return exit.ErrAborted
 	}
 
-	if o.KeepOrder && o.Limit > 1 {
+	if o.Ordered && o.Limit > 1 {
 		sort.Slice(m.items, func(i, j int) bool {
 			return m.items[i].order < m.items[j].order
 		})

--- a/choose/options.go
+++ b/choose/options.go
@@ -8,6 +8,7 @@ type Options struct {
 
 	Limit             int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit           bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	KeepOrder         bool         `help:"Keep the order of the selected options" env:"GUM_CHOOSE_KEEP_ORDER"`
 	Height            int          `help:"Height of the list" default:"10" env:"GUM_CHOOSE_HEIGHT"`
 	Cursor            string       `help:"Prefix to show on item that corresponds to the cursor position" default:"> " env:"GUM_CHOOSE_CURSOR"`
 	CursorPrefix      string       `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"○ " env:"GUM_CHOOSE_CURSOR_PREFIX"`

--- a/choose/options.go
+++ b/choose/options.go
@@ -8,7 +8,7 @@ type Options struct {
 
 	Limit             int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit           bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
-	KeepOrder         bool         `help:"Keep the order of the selected options" env:"GUM_CHOOSE_KEEP_ORDER"`
+	Ordered           bool         `help:"Maintain the order of the selected options" env:"GUM_CHOOSE_ORDERED"`
 	Height            int          `help:"Height of the list" default:"10" env:"GUM_CHOOSE_HEIGHT"`
 	Cursor            string       `help:"Prefix to show on item that corresponds to the cursor position" default:"> " env:"GUM_CHOOSE_CURSOR"`
 	CursorPrefix      string       `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"○ " env:"GUM_CHOOSE_CURSOR_PREFIX"`


### PR DESCRIPTION
resolves: #128 

### Changes

Add flag `--keep-order` for `gum choose` to maintain the order of selection and print it in the correct order at the end.
