### PR TITLE
feat(filter): added `--exact` for exact matches

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -79,7 +79,7 @@ func (o Options) Run() error {
 		selected:              make(map[string]struct{}),
 		limit:                 o.Limit,
 		reverse:               o.Reverse,
-		exact:                 o.Exact,
+		fuzzy:                 o.Fuzzy,
 	}, options...)
 
 	tm, err := p.StartReturningModel()

--- a/filter/command.go
+++ b/filter/command.go
@@ -79,6 +79,7 @@ func (o Options) Run() error {
 		selected:              make(map[string]struct{}),
 		limit:                 o.Limit,
 		reverse:               o.Reverse,
+		exact:                 o.Exact,
 	}, options...)
 
 	tm, err := p.StartReturningModel()

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -11,6 +11,7 @@
 package filter
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -274,6 +275,13 @@ func exactMatches(search string, matches []fuzzy.Match) []fuzzy.Match {
 			exactMatches = append(exactMatches, m)
 		}
 	}
+
+	// we need to sort by name the matches because
+	// they are sorted with the fuzzy ranking
+	sort.Slice(exactMatches, func(i, j int) bool {
+		return exactMatches[i].Str > exactMatches[j].Str
+	})
+
 	return exactMatches
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -42,7 +42,7 @@ type model struct {
 	selectedPrefixStyle   lipgloss.Style
 	unselectedPrefixStyle lipgloss.Style
 	reverse               bool
-	exact                 bool
+	fuzzy                 bool
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -175,14 +175,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				yOffsetFromBottom = max(0, len(m.matches)-m.viewport.YOffset)
 			}
 
-			// A character was entered, this likely means that the text input
-			// has changed. This suggests that the matches are outdated, so
-			// update them, with a fuzzy finding algorithm provided by
-			// https://github.com/sahilm/fuzzy or with an exact match search
-			if m.exact {
-				m.matches = exactMatches(m.textinput.Value(), m.choices)
-			} else {
+			// A character was entered, this likely means that the text input has
+			// changed. This suggests that the matches are outdated, so update them.
+			if m.fuzzy {
 				m.matches = fuzzy.Find(m.textinput.Value(), m.choices)
+			} else {
+				m.matches = exactMatches(m.textinput.Value(), m.choices)
 			}
 
 			// If the search field is empty, let's not display the matches
@@ -253,7 +251,7 @@ func matchAll(options []string) []fuzzy.Match {
 }
 
 func exactMatches(search string, choices []string) []fuzzy.Match {
-	exactMatches := fuzzy.Matches{}
+	matches := fuzzy.Matches{}
 	for i, choice := range choices {
 		search = strings.ToLower(search)
 		matchedString := strings.ToLower(choice)
@@ -264,7 +262,7 @@ func exactMatches(search string, choices []string) []fuzzy.Match {
 			for s := range search {
 				matchedIndexes = append(matchedIndexes, index+s)
 			}
-			exactMatches = append(exactMatches, fuzzy.Match{
+			matches = append(matches, fuzzy.Match{
 				Str:            choice,
 				Index:          i,
 				MatchedIndexes: matchedIndexes,
@@ -272,7 +270,7 @@ func exactMatches(search string, choices []string) []fuzzy.Match {
 		}
 	}
 
-	return exactMatches
+	return matches
 }
 
 //nolint:unparam

--- a/filter/options.go
+++ b/filter/options.go
@@ -21,5 +21,5 @@ type Options struct {
 	Height                int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
 	Value                 string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
 	Reverse               bool         `help:"Display from the bottom of the screen" env:"GUM_FILTER_REVERSE"`
-	Exact                 bool         `help:"Enable exact-match" env:"GUM_FILTER_EXACT"`
+	Fuzzy                 bool         `help:"Enable fuzzy matching" default:"true" env:"GUM_FILTER_FUZZY" negatable:""`
 }

--- a/filter/options.go
+++ b/filter/options.go
@@ -21,4 +21,5 @@ type Options struct {
 	Height                int          `help:"Input height" default:"0" env:"GUM_FILTER_HEIGHT"`
 	Value                 string       `help:"Initial filter value" default:"" env:"GUM_FILTER_VALUE"`
 	Reverse               bool         `help:"Display from the bottom of the screen" env:"GUM_FILTER_REVERSE"`
+	Exact                 bool         `help:"Enable exact-match" env:"GUM_FILTER_EXACT"`
 }


### PR DESCRIPTION
Fixes #50 

### Changes
Added the `--exact` flag to perform an exact filter (not fuzzy).

To highlight the correct letters I had to override the ones matched originally, and also I had to sort the slice again to avoid the "shuffling" of some elements that were ordered with the fuzzy ranking algorithm.
