### PR TITLE
updated sha256 in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,5 +3,5 @@
 pkgs.buildGoModule {
   name = "gum";
   src = ./.;
-  vendorSha256="rMqhYZMa0+5F3X4WDm4jE6IwlzOugqm65SAP38bdQx8=";
+  vendorSha256 = "sha256-rOBwhPXo4sTSI3j3rn3c5qWGnGFgkpeFUKgtzKBltbg=";
 }


### PR DESCRIPTION
Dependencies in the `go.mod` file were updated which broke the nix derivation. This fixes it.
### Changes
- Update sha256 in `default.nix` to match new dependencies.

