### PR TITLE
Doc/readme debian trusted gpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,19 +113,13 @@ nix run "github:charmbracelet/gum" -- --help
 
 # Debian/Ubuntu
 echo "deb https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
-
 curl https://repo.charm.sh/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/charm.gpg
-
 sudo apt update && sudo apt install gum
-
 
 # Debian/Ubuntu (legacy < Debian 11 and < Ubuntu 22.04)
 ## If the "apt-key is deprecated" warning is shown, should use the other Debian method.
- 
 echo "deb https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
-
 curl https://repo.charm.sh/apt/gpg.key | sudo apt-key add -
-
 sudo apt update && sudo apt install gum
 
 # Fedora

--- a/README.md
+++ b/README.md
@@ -113,7 +113,19 @@ nix run "github:charmbracelet/gum" -- --help
 
 # Debian/Ubuntu
 echo "deb https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
+
+curl https://repo.charm.sh/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/charm.gpg
+
+sudo apt update && sudo apt install gum
+
+
+# Debian/Ubuntu (legacy < Debian 11 and < Ubuntu 22.04)
+## If the "apt-key is deprecated" warning is shown, should use the other Debian method.
+ 
+echo "deb https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
+
 curl https://repo.charm.sh/apt/gpg.key | sudo apt-key add -
+
 sudo apt update && sudo apt install gum
 
 # Fedora


### PR DESCRIPTION
Fixes #208 

Currently then using `apt-key add`, a warning message is shown:

`Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))`

and, then when executing `apt udpate`:

`W: https://repo.charm.sh/apt/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.`


In this PR, I'm adding the updated instructions to avoid this warning message

### Changes
- Adding current gpg key management for apt package manager
