### PR TITLE
docs: apt-key deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,12 @@ nix-env -iA nixpkgs.gum
 nix run "github:charmbracelet/gum" -- --help
 
 # Debian/Ubuntu
-echo "deb https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
-curl https://repo.charm.sh/apt/gpg.key | sudo apt-key add -
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
 sudo apt update && sudo apt install gum
 
-# Fedora
+# Fedora/RHEL
 echo '[charm]
 name=Charm
 baseurl=https://repo.charm.sh/yum/


### PR DESCRIPTION
Use the recommended keyrings path /etc/apt/keyrings

Per: https://manpages.debian.org/unstable/apt/apt-key.8.en.html#DEPRECATION
Fixes: https://github.com/charmbracelet/gum/issues/208
Fixes: https://github.com/charmbracelet/gum/pull/209

