### PR TITLE
feat: allow customization of glamour theme

### DIFF
--- a/format/command.go
+++ b/format/command.go
@@ -17,30 +17,30 @@ import (
 	"github.com/charmbracelet/gum/internal/stdin"
 )
 
-// Func is a function that formats some text.
-type Func func(string) (string, error)
-
-var formatType = map[string]Func{
-	"code":     code,
-	"emoji":    emoji,
-	"markdown": markdown,
-	"template": template,
-}
-
 // Run runs the format command.
 func (o Options) Run() error {
-	var input string
+	var input, output string
+	var err error
 	if len(o.Template) > 0 {
 		input = strings.Join(o.Template, "\n")
 	} else {
 		input, _ = stdin.Read()
 	}
 
-	v, err := formatType[o.Type](input)
+	switch o.Type {
+	case "code":
+		output, err = code(input)
+	case "emoji":
+		output, err = emoji(input)
+	case "template":
+		output, err = template(input)
+	default:
+		output, err = markdown(input, o.Theme)
+	}
 	if err != nil {
 		return err
 	}
 
-	fmt.Print(v)
+	fmt.Print(output)
 	return nil
 }

--- a/format/formats.go
+++ b/format/formats.go
@@ -9,7 +9,7 @@ import (
 	"github.com/muesli/termenv"
 )
 
-var code Func = func(input string) (string, error) {
+func code(input string) (string, error) {
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 		glamour.WithWordWrap(0),
@@ -24,7 +24,7 @@ var code Func = func(input string) (string, error) {
 	return output, nil
 }
 
-var emoji Func = func(input string) (string, error) {
+func emoji(input string) (string, error) {
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithEmoji(),
 	)
@@ -38,13 +38,13 @@ var emoji Func = func(input string) (string, error) {
 	return output, nil
 }
 
-var markdown Func = func(input string) (string, error) {
+func markdown(input string, theme string) (string, error) {
 	renderer, err := glamour.NewTermRenderer(
-		glamour.WithStandardStyle("pink"),
+		glamour.WithStylePath(theme),
 		glamour.WithWordWrap(0),
 	)
 	if err != nil {
-		return "", fmt.Errorf("unable to create renderer: %w", err)
+		return "", fmt.Errorf("unable to render: %w", err)
 	}
 	output, err := renderer.Render(input)
 	if err != nil {
@@ -53,7 +53,7 @@ var markdown Func = func(input string) (string, error) {
 	return output, nil
 }
 
-var template Func = func(input string) (string, error) {
+func template(input string) (string, error) {
 	f := termenv.TemplateFuncs(termenv.ColorProfile())
 	t, err := tpl.New("tpl").Funcs(f).Parse(input)
 	if err != nil {

--- a/format/options.go
+++ b/format/options.go
@@ -3,6 +3,7 @@ package format
 // Options is customization options for the format command.
 type Options struct {
 	Template []string `arg:"" optional:"" help:"Template string to format (can also be provided via stdin)"`
+	Theme    string   `help:"Glamour theme to use for markdown formatting" default:"pink"`
 
 	Type string `help:"Format to use (markdown,template,code,emoji)" enum:"markdown,template,code,emoji" short:"t" default:"markdown"`
 }


### PR DESCRIPTION
Add `--theme` option for customizing Glamour theme used in `gum format`.

The `--theme` can be either a file path or a standard style such as:
* `auto`
* `dark`
* `light`
* `notty`
* `ascii`
* `dracula`
* `pink` (default)
