### PR TITLE
docs: add Alpine & termux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ enabled=1
 gpgcheck=1
 gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
 sudo yum install gum
+
+# Alpine
+apk add gum
+
+# Android (via termux)
+pkg install gum
 ```
 
 Or download it:


### PR DESCRIPTION
Makes the README instructions even more crowded, but hey, gum on Android?!