### PR TITLE
fix(table): output proper CSV for the selected row

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -4,7 +4,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/table"
@@ -102,7 +101,11 @@ func (o Options) Run() error {
 	}
 
 	m := tm.(model)
-	fmt.Println(strings.Join([]string(m.selected), o.Separator))
+
+	w := csv.NewWriter(os.Stdout)
+	w.Comma = reader.Comma
+	w.Write([]string(m.selected))
+	w.Flush()
 
 	return nil
 }

--- a/table/command.go
+++ b/table/command.go
@@ -105,8 +105,7 @@ func (o Options) Run() error {
 
 	m := tm.(model)
 
-	err = writer.Write([]string(m.selected))
-	if err != nil {
+	if err = writer.Write([]string(m.selected)); err != nil {
 		return fmt.Errorf("failed to write selected row: %w", err)
 	}
 

--- a/table/command.go
+++ b/table/command.go
@@ -36,6 +36,9 @@ func (o Options) Run() error {
 	}
 	reader.Comma = separatorRunes[0]
 
+	writer := csv.NewWriter(os.Stdout)
+	writer.Comma = separatorRunes[0]
+
 	var columnNames []string
 	var err error
 	// If no columns are provided we'll use the first row of the CSV as the
@@ -102,10 +105,12 @@ func (o Options) Run() error {
 
 	m := tm.(model)
 
-	w := csv.NewWriter(os.Stdout)
-	w.Comma = reader.Comma
-	w.Write([]string(m.selected))
-	w.Flush()
+	err = writer.Write([]string(m.selected))
+	if err != nil {
+		return fmt.Errorf("failed to write selected row: %w", err)
+	}
+
+	writer.Flush()
 
 	return nil
 }


### PR DESCRIPTION
### Changes
- `gum table` outputs proper CSV

#### Columns with commas in them

Before:
![table-pr-before-1](https://user-images.githubusercontent.com/628/200089388-46a37d70-a892-4ece-bc05-5758636eded3.gif)

After:

![table-pr-after-1](https://user-images.githubusercontent.com/628/200089469-f7c6f61b-6f3d-49d8-827a-0f171136c244.gif)

#### Columns with escaped quotes

Before:
![table-pr-before-2](https://user-images.githubusercontent.com/628/200089525-b248c182-6fd6-472f-b212-2fe7ea5a2230.gif)


After:
![table-pr-after-2](https://user-images.githubusercontent.com/628/200089534-33f217fc-f187-4fea-8201-1380b2e09ceb.gif)

