### PR TITLE
feature(choose): Adding option to use non-matching filter as result

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -87,7 +87,6 @@ func (o Options) Run() error {
 		return fmt.Errorf("unable to run filter: %w", err)
 	}
 	m := tm.(model)
-
 	if m.aborted {
 		return exit.ErrAborted
 	}
@@ -103,6 +102,9 @@ func (o Options) Run() error {
 		fmt.Println(m.matches[m.cursor].Str)
 	}
 
+	if o.NoMatchNeeded && len(m.textinput.Value()) != 0 {
+		fmt.Println(m.textinput.Value())
+	}
 	return nil
 }
 

--- a/filter/command.go
+++ b/filter/command.go
@@ -102,7 +102,7 @@ func (o Options) Run() error {
 		fmt.Println(m.matches[m.cursor].Str)
 	}
 
-	if o.NoMatchNeeded && len(m.textinput.Value()) != 0 && len(m.matches) == 0 {
+	if !o.Strict && len(m.textinput.Value()) != 0 && len(m.matches) == 0 {
 		fmt.Println(m.textinput.Value())
 	}
 	return nil

--- a/filter/command.go
+++ b/filter/command.go
@@ -102,7 +102,7 @@ func (o Options) Run() error {
 		fmt.Println(m.matches[m.cursor].Str)
 	}
 
-	if o.NoMatchNeeded && len(m.textinput.Value()) != 0 {
+	if o.NoMatchNeeded && len(m.textinput.Value()) != 0 && len(m.matches) == 0 {
 		fmt.Println(m.textinput.Value())
 	}
 	return nil

--- a/filter/options.go
+++ b/filter/options.go
@@ -8,7 +8,7 @@ type Options struct {
 	IndicatorStyle        style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
 	Limit                 int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit               bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
-	NoMatchNeeded         bool         `help:"Only returns if anything matched. Otherwise return Filter" group:"Selection"`
+	Strict                bool         `help:"Only returns if anything matched. Otherwise return Filter" negatable:"true" default:"true" group:"Selection"`
 	SelectedPrefix        string       `help:"Character to indicate selected items (hidden if limit is 1)" default:" ◉ " env:"GUM_FILTER_SELECTED_PREFIX"`
 	SelectedPrefixStyle   style.Styles `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_PREFIX_"`
 	UnselectedPrefix      string       `help:"Character to indicate unselected items (hidden if limit is 1)" default:" ○ " env:"GUM_FILTER_UNSELECTED_PREFIX"`

--- a/filter/options.go
+++ b/filter/options.go
@@ -8,6 +8,7 @@ type Options struct {
 	IndicatorStyle        style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
 	Limit                 int          `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit               bool         `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	NoMatchNeeded         bool         `help:"Only returns if anything matched. Otherwise return Filter" group:"Selection"`
 	SelectedPrefix        string       `help:"Character to indicate selected items (hidden if limit is 1)" default:" ◉ " env:"GUM_FILTER_SELECTED_PREFIX"`
 	SelectedPrefixStyle   style.Styles `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_PREFIX_"`
 	UnselectedPrefix      string       `help:"Character to indicate unselected items (hidden if limit is 1)" default:" ○ " env:"GUM_FILTER_UNSELECTED_PREFIX"`


### PR DESCRIPTION
Small enhancement to the filter to allow a non matching filter to be a valid 
result. 

### Changes
New Option --no-strict to take filter string if no match was found

<img width="645" alt="image" src="https://user-images.githubusercontent.com/3485445/200904597-f0eb21e7-7513-4edf-8494-f8f09993653a.png">

<img width="488" alt="image" src="https://user-images.githubusercontent.com/3485445/200808434-67a67aa4-8bfb-4b2f-89f7-684fbaf41107.png">

<img width="233" alt="image" src="https://user-images.githubusercontent.com/3485445/200808503-1ad06dba-3090-4007-a0ab-ab2d5a07a42d.png">


