### PR TITLE
"feature(230): Adding optional Cancel Option to gum confirm

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -19,32 +19,32 @@ func (o Options) Run() error {
 	var (
 		options        []string
 		selectedOption selectionType
+		theDefault     bool
 	)
 	// set options
 	options = append(options, o.Affirmative)
-	if o.Negative != "" {
-		options = append(options, o.Negative)
-	}
-	if o.Canceled != "" && o.WithCancel {
-		options = append(options, o.Canceled)
-	}
+	options = append(options, o.Negative)
+	options = append(options, o.Canceled)
 
 	// what is default
+	theDefault = o.Default
 	if !o.Default && o.Negative != "" {
 		selectedOption = Negative
 	} else {
 		selectedOption = Confirmed
+		theDefault = true
 	}
 
 	m, err := tea.NewProgram(model{
-		options:         options,
-		selectedOption:  selectedOption,
-		timeout:         o.Timeout,
-		hasTimeout:      o.Timeout > 0,
-		prompt:          o.Prompt,
-		selectedStyle:   o.SelectedStyle.ToLipgloss(),
-		unselectedStyle: o.UnselectedStyle.ToLipgloss(),
-		promptStyle:     o.PromptStyle.ToLipgloss(),
+		options:          options,
+		selectedOption:   selectedOption,
+		timeout:          o.Timeout,
+		hasTimeout:       o.Timeout > 0,
+		prompt:           o.Prompt,
+		defaultSelection: theDefault,
+		selectedStyle:    o.SelectedStyle.ToLipgloss(),
+		unselectedStyle:  o.UnselectedStyle.ToLipgloss(),
+		promptStyle:      o.PromptStyle.ToLipgloss(),
 	}, tea.WithOutput(os.Stderr)).Run()
 
 	if err != nil {
@@ -57,7 +57,6 @@ func (o Options) Run() error {
 	case Negative:
 		os.Exit(1)
 	case Cancel:
-
 		os.Exit(CtrlC)
 	}
 

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -15,7 +15,7 @@ import (
 func (o Options) Run() error {
 	var (
 		options        []string
-		selectedOption Confirmation
+		selectedOption selectionType
 	)
 	// set options
 	options = append(options, o.Affirmative)

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -10,6 +10,8 @@ import (
 	"github.com/charmbracelet/gum/style"
 )
 
+const CTRL_C = 130
+
 // Run provides a shell script interface for prompting a user to confirm an
 // action with an affirmative or negative answer.
 func (o Options) Run() error {
@@ -54,7 +56,8 @@ func (o Options) Run() error {
 	case Negative:
 		os.Exit(1)
 	case Cancel:
-		os.Exit(130)
+
+		os.Exit(CTRL_C)
 	}
 
 	return nil

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -24,7 +24,11 @@ func (o Options) Run() error {
 	// set options
 	options = append(options, o.Affirmative)
 	options = append(options, o.Negative)
-	options = append(options, o.Canceled)
+	if o.WithCancel {
+		options = append(options, o.Canceled)
+	} else {
+		options = append(options, "")
+	}
 
 	// what is default
 	theDefault = o.Default

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/gum/style"
 )
 
+// CTRL_C Default Return code in case of ctrl-c by user.
 const CTRL_C = 130
 
 // Run provides a shell script interface for prompting a user to confirm an

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -10,8 +10,8 @@ import (
 	"github.com/charmbracelet/gum/style"
 )
 
-// CTRL_C Default Return code in case of ctrl-c by user.
-const CTRL_C = 130
+// Ctrl_c Default Return code in case of ctrl-c by user.
+const Ctrl_c = 130
 
 // Run provides a shell script interface for prompting a user to confirm an
 // action with an affirmative or negative answer.
@@ -58,7 +58,7 @@ func (o Options) Run() error {
 		os.Exit(1)
 	case Cancel:
 
-		os.Exit(CTRL_C)
+		os.Exit(Ctrl_c)
 	}
 
 	return nil

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -10,8 +10,8 @@ import (
 	"github.com/charmbracelet/gum/style"
 )
 
-// Ctrl_c Default Return code in case of ctrl-c by user.
-const Ctrl_c = 130
+// CtrlC Default Return code in case of ctrl-c by user.
+const CtrlC = 130
 
 // Run provides a shell script interface for prompting a user to confirm an
 // action with an affirmative or negative answer.
@@ -58,7 +58,7 @@ func (o Options) Run() error {
 		os.Exit(1)
 	case Cancel:
 
-		os.Exit(Ctrl_c)
+		os.Exit(CtrlC)
 	}
 
 	return nil

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -20,7 +20,8 @@ import (
 
 type selectionType int
 
-// Type of user selection
+// Type of user selection.:w
+
 const (
 	Confirmed selectionType = iota
 	Negative

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -20,6 +20,7 @@ import (
 
 type selectionType int
 
+// Type of user selection
 const (
 	Confirmed selectionType = iota
 	Negative

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -94,6 +94,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.options[Negative] != "" {
 				m.selectedOption = Negative
 				m.quitting = true
+				return m, tea.Quit
 			}
 		case "ctrl+c":
 			m.selectedOption = Cancel

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -18,10 +18,10 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-type Confirmation int
+type selectionType int
 
 const (
-	Confirmed Confirmation = iota
+	Confirmed selectionType = iota
 	Negative
 	Cancel
 )
@@ -33,7 +33,7 @@ type model struct {
 	hasTimeout bool
 	timeout    time.Duration
 
-	selectedOption Confirmation
+	selectedOption selectionType
 
 	// styles
 	promptStyle     lipgloss.Style
@@ -68,7 +68,7 @@ func (m *model) NextOption() {
 func (m *model) PrevOption() {
 	m.selectedOption--
 	if (int)(m.selectedOption) < 0 {
-		m.selectedOption = Confirmation(len(m.options) - 1)
+		m.selectedOption = selectionType(len(m.options) - 1)
 	}
 }
 

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -21,7 +21,6 @@ import (
 type selectionType int
 
 // Type of user selection.:w
-
 const (
 	Confirmed selectionType = iota
 	Negative

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -10,8 +10,10 @@ import (
 type Options struct {
 	Affirmative string        `help:"The title of the affirmative action" default:"Yes"`
 	Negative    string        `help:"The title of the negative action" default:"No"`
-	Default     bool          `help:"Default confirmation action" default:"true"`
-	Timeout     time.Duration `help:"Timeout for confirmation" default:"0" env:"GUM_CONFIRM_TIMEOUT"`
+	Canceled    string        `help:"The title of the canceled action" default:"Cancel"`
+	Default     bool          `help:"Default selectedOption action" default:"true"`
+	WithCancel  bool          `help:"Display Cancel option" default:"false"`
+	Timeout     time.Duration `help:"Timeout for selectedOption" default:"0" env:"GUM_CONFIRM_TIMEOUT"`
 	Prompt      string        `arg:"" help:"Prompt to display." default:"Are you sure?"`
 	PromptStyle style.Styles  `embed:"" prefix:"prompt." help:"The style of the prompt" set:"defaultMargin=1 0 0 0" envprefix:"GUM_CONFIRM_PROMPT_"`
 	//nolint:staticcheck


### PR DESCRIPTION
Fixes #230 

### Changes
- New Option to enable explicit Cancel Button
- Return 130 for either explicit Cancel Button or pressing ctrl-c
- Refactor some code


<img width="264" alt="image" src="https://user-images.githubusercontent.com/3485445/203035119-bcf25b8f-24ac-4e34-9f8b-e73778fba20a.png">

<img width="319" alt="image" src="https://user-images.githubusercontent.com/3485445/203035286-03104ba0-cc94-4293-b061-0a9f3f9636e6.png">

<img width="284" alt="image" src="https://user-images.githubusercontent.com/3485445/203035419-73c7bec1-86d8-4f31-a0b2-af8bbb900f37.png">

<img width="345" alt="image" src="https://user-images.githubusercontent.com/3485445/203035562-8c2fc840-adf4-4d21-a206-afd4e691bf20.png">

