### PR TITLE
feat(pager): add --soft-wrap option to gum pager

### DIFF
--- a/pager/command.go
+++ b/pager/command.go
@@ -34,6 +34,7 @@ func (o Options) Run() error {
 		content:         o.Content,
 		showLineNumbers: o.ShowLineNumbers,
 		lineNumberStyle: o.LineNumberStyle.ToLipgloss(),
+		softWrap:        o.SoftWrap,
 	}
 	_, err := tea.NewProgram(model, tea.WithAltScreen()).Run()
 	if err != nil {

--- a/pager/options.go
+++ b/pager/options.go
@@ -10,4 +10,5 @@ type Options struct {
 	Content         string       `arg:"" optional:"" help:"Display content to scroll"`
 	ShowLineNumbers bool         `help:"Show line numbers" default:"true"`
 	LineNumberStyle style.Styles `embed:"" prefix:"line-number." help:"Style the line numbers" set:"defaultForeground=237" envprefix:"GUM_PAGER_LINE_NUMBER_"`
+	SoftWrap        bool         `help:"Soft wrap lines" default:"false"`
 }


### PR DESCRIPTION
Partially implements #246

### Changes

Adds a `--soft-wrap` option to the `gum pager` command. This will simply wrap lines to the next line in the pager.

Before:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/4819194/205972385-e06e0fdf-a738-407a-8e7c-353a4fab63f9.png">

After:
<img width="673" alt="image" src="https://user-images.githubusercontent.com/4819194/205972662-0f794f25-ad60-4306-b61a-5a6cda57916f.png">

Without line numbers:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/4819194/205972695-dda9df80-efa3-45c1-9770-b4ff347f0444.png">

 