### PR TITLE
feat: ctrl+c / esc aborts action

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -29,7 +29,9 @@ func (o Options) Run() error {
 		return fmt.Errorf("unable to run confirm: %w", err)
 	}
 
-	if m.(model).confirmation {
+	if m.(model).aborted {
+		os.Exit(130)
+	} else if m.(model).confirmation {
 		os.Exit(0)
 	} else {
 		os.Exit(1)

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -23,6 +23,7 @@ type model struct {
 	affirmative string
 	negative    string
 	quitting    bool
+	aborted     bool
 	hasTimeout  bool
 	timeout     time.Duration
 
@@ -57,7 +58,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc", "q", "n", "N":
+		case "ctrl+c", "esc":
+			m.confirmation = false
+			m.aborted = true
+			m.quitting = true
+			return m, tea.Quit
+		case "q", "n", "N":
 			m.confirmation = false
 			m.quitting = true
 			return m, tea.Quit


### PR DESCRIPTION
Fixes #230

### Changes
- Adds exit 130 to <kbd>ctrl+c</kbd> and <kbd>esc</kbd>
