### PR TITLE
Added Scoop installation instructions for gum

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ apk add gum
 
 # Android (via termux)
 pkg install gum
+
+# Windows (via Scoop)
+scoop install charm-gum
 ```
 
 Or download it:


### PR DESCRIPTION
I recently just had charm's **gum** added to Scoop. It can be installed with the following commands:
```bash
scoop install charm-gum
```

### Changes
- README.md
