### PR TITLE
Add staged file check for commit example

### DIFF
--- a/examples/commit.sh
+++ b/examples/commit.sh
@@ -20,5 +20,11 @@ test -n "$SCOPE" && SCOPE="($SCOPE)"
 SUMMARY=$(gum input --value "$TYPE$SCOPE: " --placeholder "Summary of this change")
 DESCRIPTION=$(gum write --placeholder "Details of this change")
 
+# Check if any staged files are present. If there are non, ask the user if 
+# they want to commit all files
+if [ -z "$(git status -s -uno | grep -v '^ ' | awk '{print $2}')" ]; then
+    gum confirm "No staged files. Commit all?" && git add .
+fi
+
 # Commit these changes if user confirms
 gum confirm "Commit changes?" && git commit -m "$SUMMARY" -m "$DESCRIPTION"

--- a/examples/commit.sh
+++ b/examples/commit.sh
@@ -10,6 +10,10 @@
 #
 # alias gcm='git commit -m "$(gum input)" -m "$(gum write)"'
 
+if [ -z "$(git status -s -uno | grep -v '^ ' | awk '{print $2}')" ]; then
+    gum confirm "Stage all?" && git add .
+fi
+
 TYPE=$(gum choose "fix" "feat" "docs" "style" "refactor" "test" "chore" "revert")
 SCOPE=$(gum input --placeholder "scope")
 
@@ -19,12 +23,6 @@ test -n "$SCOPE" && SCOPE="($SCOPE)"
 # Pre-populate the input with the type(scope): so that the user may change it
 SUMMARY=$(gum input --value "$TYPE$SCOPE: " --placeholder "Summary of this change")
 DESCRIPTION=$(gum write --placeholder "Details of this change")
-
-# Check if any staged files are present. If there are non, ask the user if 
-# they want to commit all files
-if [ -z "$(git status -s -uno | grep -v '^ ' | awk '{print $2}')" ]; then
-    gum confirm "No staged files. Commit all?" && git add .
-fi
 
 # Commit these changes if user confirms
 gum confirm "Commit changes?" && git commit -m "$SUMMARY" -m "$DESCRIPTION"


### PR DESCRIPTION
I found out that I had to [add these 3 lines to my `commit` script](https://github.com/GeekMasher/.dotfiles/blob/main/dev/.local/commit) using Gum to make sure if I didn't commit anything I would be prompted if I wanted to include all of the unstaged files.

The big issue with this snippet is that it uses `grep` and `awk` so if a user doesn't have these of their system, it would fail.

I don't know if there is a better way to do this so I'm leaving it like this.

### Changes

- Added check to commit example in the case of no staged commits