### PR TITLE
build: update go version to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,26 +1,43 @@
 module github.com/charmbracelet/gum
 
-go 1.16
+go 1.17
 
 require (
 	github.com/alecthomas/kong v0.7.1
 	github.com/alecthomas/mango-kong v0.1.0
-	github.com/aymanbagabas/go-osc52 v1.2.1 // indirect
 	github.com/charmbracelet/bubbles v0.14.1-0.20221006154229-d1775121146a
 	github.com/charmbracelet/bubbletea v0.23.1
 	github.com/charmbracelet/glamour v0.5.1-0.20220727184942-e70ff2d969da
 	github.com/charmbracelet/lipgloss v0.6.1-0.20220930064401-ae7c84f7b158
-	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/dustin/go-humanize v1.0.1
 	github.com/mattn/go-runewidth v0.0.14
-	github.com/microcosm-cc/bluemonday v1.0.21 // indirect
-	github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70 // indirect
-	github.com/muesli/mango v0.2.0 // indirect
 	github.com/muesli/roff v0.1.0
 	github.com/muesli/termenv v0.13.0
 	github.com/sahilm/fuzzy v0.1.0
+)
+
+require (
+	github.com/alecthomas/chroma v0.10.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52 v1.2.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/containerd/console v1.0.3 // indirect
+	github.com/dlclark/regexp2 v1.7.0 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.21 // indirect
+	github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70 // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/mango v0.2.0 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/yuin/goldmark v1.5.2 // indirect
+	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/net v0.0.0-20221017152216-f25eb7ecb193 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20221017184919-83659145692c // indirect
 	golang.org/x/text v0.4.0 // indirect
 )


### PR DESCRIPTION
Fixes errors when building with go versions below v1.17

```bash
$ go version
go version go1.16 darwin/arm64
$ go build
# golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall.go:83:16: undefined: unsafe.Slice
../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall_darwin.go:95:8: undefined: unsafe.Slice
../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
../../go/pkg/mod/golang.org/x/sys@v0.1.0/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
note: module requires Go 1.17
```

### Changes
- `go mod edit -go=1.17`
- `go mod tidy`
