### PR TITLE
fix: for using --value in combination w/ --no-fuzzy

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -53,8 +53,13 @@ func (o Options) Run() error {
 	var matches []fuzzy.Match
 	if o.Value != "" {
 		i.SetValue(o.Value)
+	}
+	switch {
+	case o.Value != "" && o.Fuzzy:
 		matches = fuzzy.Find(o.Value, choices)
-	} else {
+	case o.Value != "" && !o.Fuzzy:
+		matches = exactMatches(o.Value, choices)
+	default:
 		matches = matchAll(choices)
 	}
 


### PR DESCRIPTION
Fixes #292

### Changes
- Added a switch to check for the combination of the two flags
- Kept the original behaviour of using fuzzy if the --no-fuzzy flag isn't present
