### PR TITLE
fixes errors with CR in write --value

### DIFF
--- a/write/command.go
+++ b/write/command.go
@@ -3,6 +3,7 @@ package write
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/textarea"
@@ -18,7 +19,7 @@ import (
 func (o Options) Run() error {
 	in, _ := stdin.Read()
 	if in != "" && o.Value == "" {
-		o.Value = in
+		o.Value = strings.Replace(in, "\r", "", -1)
 	}
 
 	a := textarea.New()


### PR DESCRIPTION
Fixes #295

### Changes
- Remove carriage returns from the value read using stdin.

This fixes the bug in gum at least, even though it's probably better to find the bugs' origination in bubbletea or the bubbles project.
