### PR TITLE
fix: table ignores foreground color set by the user

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -74,7 +74,7 @@ func (o Options) Run() error {
 	styles := table.Styles{
 		Cell:     defaultStyles.Cell.Inherit(o.CellStyle.ToLipgloss()),
 		Header:   defaultStyles.Header.Inherit(o.HeaderStyle.ToLipgloss()),
-		Selected: defaultStyles.Selected.Inherit(o.SelectedStyle.ToLipgloss()),
+		Selected: o.SelectedStyle.ToLipgloss(),
 	}
 
 	var rows = make([]table.Row, 0, len(data))


### PR DESCRIPTION
Fixes #294

### Changes
- Removed the inheritance function because when setting the selected style it would not allow changes to already set values. The default colour remains unchanged, and now it's the user's choice whether the selected text should be bold or not.

This can also be fixed by removing the setter of the foreground colour on this [line](https://github.com/charmbracelet/bubbles/blob/1ca90b3c942b5833c53a6fdfef78cd1fddfe6025/table/table.go#L100) in the bubbles project.