### PR TITLE
removed bksp from stdin

### DIFF
--- a/pager/command.go
+++ b/pager/command.go
@@ -2,12 +2,12 @@ package pager
 
 import (
 	"fmt"
-
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/gum/internal/stdin"
 	"github.com/charmbracelet/gum/style"
+	"regexp"
 )
 
 // Run provides a shell script interface for the viewport bubble.
@@ -22,7 +22,9 @@ func (o Options) Run() error {
 			return fmt.Errorf("unable to read stdin")
 		}
 		if stdin != "" {
-			o.Content = stdin
+			// Sanitize the input from stdin by removing backspace sequences.
+			backspace := regexp.MustCompile(".\x08")
+			o.Content = backspace.ReplaceAllString(stdin, "")
 		} else {
 			return fmt.Errorf("provide some content to display")
 		}

--- a/pager/command.go
+++ b/pager/command.go
@@ -2,12 +2,13 @@ package pager
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/gum/internal/stdin"
 	"github.com/charmbracelet/gum/style"
-	"regexp"
 )
 
 // Run provides a shell script interface for the viewport bubble.

--- a/write/command.go
+++ b/write/command.go
@@ -19,7 +19,7 @@ import (
 func (o Options) Run() error {
 	in, _ := stdin.Read()
 	if in != "" && o.Value == "" {
-		o.Value = strings.Replace(in, "\r", "", -1)
+		o.Value = strings.ReplaceAll(in, "\r", "")
 	}
 
 	a := textarea.New()


### PR DESCRIPTION
Fixes #297

### Changes
- Removes backspaces, including the character before it, using a regex. The problem stems from when setting the variable and calling the pager, you get the man pages in their nroff format. Which means that it includes ^H chars, and I suspect that hinders bubbletea from calculating the width correctly.