### PR TITLE
fix: added esc to keys and changed error code to 130

### DIFF
--- a/file/command.go
+++ b/file/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/filepicker"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/gum/internal/exit"
 	"github.com/charmbracelet/gum/style"
 )
 
@@ -53,6 +54,9 @@ func (o Options) Run() error {
 	}
 
 	m = tm.(model)
+	if m.aborted {
+		return exit.ErrAborted
+	}
 
 	if m.selectedPath == "" {
 		os.Exit(1)

--- a/file/file.go
+++ b/file/file.go
@@ -20,6 +20,7 @@ import (
 type model struct {
 	filepicker   filepicker.Model
 	selectedPath string
+	aborted      bool
 	quitting     bool
 }
 
@@ -31,7 +32,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c", "q", "esc":
+			m.aborted = true
+			m.quitting = true
 			return m, tea.Quit
 		}
 	}


### PR DESCRIPTION
Fixes #315

### Changes
- Make escape also quit `file`
- Change the returning error code to 130

I tried to make the behaviour as similar as the one from `filter`/`chose`.