### PR TITLE
fix: changed logic in stdin and stopped ignoring err in filter

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -32,14 +32,16 @@ func (o Options) Run() error {
 	v := viewport.New(o.Width, o.Height)
 
 	var choices []string
-	if input, err := stdin.Read(); input != "" && err == nil {
+	input, err := stdin.Read()
+	switch {
+	case err != nil:
+		return fmt.Errorf("%v", err)
+	case input != "":
 		input = strings.TrimSuffix(input, "\n")
 		if input != "" {
 			choices = strings.Split(input, "\n")
 		}
-	} else if err != nil {
-		return fmt.Errorf("%v", err)
-	} else {
+	default:
 		choices = files.List()
 	}
 

--- a/filter/command.go
+++ b/filter/command.go
@@ -32,11 +32,13 @@ func (o Options) Run() error {
 	v := viewport.New(o.Width, o.Height)
 
 	var choices []string
-	if input, _ := stdin.Read(); input != "" {
+	if input, err := stdin.Read(); input != "" && err == nil {
 		input = strings.TrimSuffix(input, "\n")
 		if input != "" {
 			choices = strings.Split(input, "\n")
 		}
+	} else if err != nil {
+		return fmt.Errorf("%v", err)
 	} else {
 		choices = files.List()
 	}

--- a/filter/command.go
+++ b/filter/command.go
@@ -32,16 +32,12 @@ func (o Options) Run() error {
 	v := viewport.New(o.Width, o.Height)
 
 	var choices []string
-	input, err := stdin.Read()
-	switch {
-	case err != nil:
-		return fmt.Errorf("%v", err)
-	case input != "":
+	if input, _ := stdin.Read(); input != "" {
 		input = strings.TrimSuffix(input, "\n")
 		if input != "" {
 			choices = strings.Split(input, "\n")
 		}
-	default:
+	} else {
 		choices = files.List()
 	}
 

--- a/internal/stdin/stdin.go
+++ b/internal/stdin/stdin.go
@@ -28,10 +28,6 @@ func Read() (string, error) {
 		}
 	}
 
-	if len(b.String()) <= 0 {
-		return "", fmt.Errorf("stdin is empty")
-	}
-
 	return b.String(), nil
 }
 

--- a/internal/stdin/stdin.go
+++ b/internal/stdin/stdin.go
@@ -19,13 +19,17 @@ func Read() (string, error) {
 
 	for {
 		r, _, err := reader.ReadRune()
-		if err != nil && err == io.EOF {
+		if err != nil || err == io.EOF {
 			break
 		}
 		_, err = b.WriteRune(r)
 		if err != nil {
 			return "", fmt.Errorf("failed to write rune: %w", err)
 		}
+	}
+
+	if len(b.String()) <= 0 {
+		return "", fmt.Errorf("stdin is empty")
 	}
 
 	return b.String(), nil


### PR DESCRIPTION
Fixes #313


### Changes
- Change logic in stdin to look for EOF or err
- Check when existing for loop if string is empty
- Check error in the `filter` command

Before:
![demo](https://user-images.githubusercontent.com/34864484/226329076-e894da51-eb3e-42e9-a884-ba8a20d6e7ff.gif)

After:
![demo](https://user-images.githubusercontent.com/34864484/226329264-11c82203-7eb0-45dc-8686-6347992f0a0b.gif)

