### PR TITLE
fix: correct wrong key combination for gum write in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ gum input --password > password.txt
 
 Prompt for some multi-line text.
 
-Note: `CTRL+D` and `esc` are used to complete text entry. `CTRL+C` will cancel.
+Note: `CTRL+D` is used to complete text entry. `CTRL+C` and `esc` will cancel.
 
 ```bash
 gum write > story.txt


### PR DESCRIPTION
Fixes #312

### Changes:
 - Moves the `esc` over to the cancel option together with CTRL+c, so it reflects the current behaviour of the program.
