### PR TITLE
feat(filter): add cursor text line styling

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -84,6 +84,7 @@ func (o Options) Run() error {
 		matchStyle:            o.MatchStyle.ToLipgloss(),
 		headerStyle:           o.HeaderStyle.ToLipgloss(),
 		textStyle:             o.TextStyle.ToLipgloss(),
+		cursorTextStyle:       o.CursorTextStyle.ToLipgloss(),
 		height:                o.Height,
 		selected:              make(map[string]struct{}),
 		limit:                 o.Limit,

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -39,6 +39,7 @@ type model struct {
 	headerStyle           lipgloss.Style
 	matchStyle            lipgloss.Style
 	textStyle             lipgloss.Style
+	cursorTextStyle       lipgloss.Style
 	indicatorStyle        lipgloss.Style
 	selectedPrefixStyle   lipgloss.Style
 	unselectedPrefixStyle lipgloss.Style
@@ -54,6 +55,7 @@ func (m model) View() string {
 	}
 
 	var s strings.Builder
+	var lineTextStyle lipgloss.Style
 
 	// For reverse layout, if the number of matches is less than the viewport
 	// height, we need to offset the matches so that the first match is at the
@@ -74,10 +76,14 @@ func (m model) View() string {
 
 		// If this is the current selected index, we add a small indicator to
 		// represent it. Otherwise, simply pad the string.
+		// The line's text style is set depending on whether or not the cursor
+		// points to this line.
 		if i == m.cursor {
 			s.WriteString(m.indicatorStyle.Render(m.indicator))
+			lineTextStyle = m.cursorTextStyle
 		} else {
 			s.WriteString(strings.Repeat(" ", lipgloss.Width(m.indicator)))
+			lineTextStyle = m.textStyle
 		}
 
 		// If there are multiple selections mark them, otherwise leave an empty space
@@ -99,7 +105,7 @@ func (m model) View() string {
 			// index. If so, color the character to indicate a match.
 			if mi < len(match.MatchedIndexes) && ci == match.MatchedIndexes[mi] {
 				// Flush text buffer.
-				s.WriteString(m.textStyle.Render(buf.String()))
+				s.WriteString(lineTextStyle.Render(buf.String()))
 				buf.Reset()
 
 				s.WriteString(m.matchStyle.Render(string(c)))
@@ -112,7 +118,7 @@ func (m model) View() string {
 			}
 		}
 		// Flush text buffer.
-		s.WriteString(m.textStyle.Render(buf.String()))
+		s.WriteString(lineTextStyle.Render(buf.String()))
 
 		// We have finished displaying the match with all of it's matched
 		// characters highlighted and the rest filled in.

--- a/filter/options.go
+++ b/filter/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	HeaderStyle           style.Styles `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_FILTER_HEADER_"`
 	Header                string       `help:"Header value" default:"" env:"GUM_FILTER_HEADER"`
 	TextStyle             style.Styles `embed:"" prefix:"text." envprefix:"GUM_FILTER_TEXT_"`
+	CursorTextStyle       style.Styles `embed:"" prefix:"cursor-text." envprefix:"GUM_FILTER_CURSOR_TEXT_"`
 	MatchStyle            style.Styles `embed:"" prefix:"match." set:"defaultForeground=212" envprefix:"GUM_FILTER_MATCH_"`
 	Placeholder           string       `help:"Placeholder value" default:"Filter..." env:"GUM_FILTER_PLACEHOLDER"`
 	Prompt                string       `help:"Prompt to display" default:"> " env:"GUM_FILTER_PROMPT"`


### PR DESCRIPTION
Fixes nothing, this is a feature I wanted to have access to in `gum`.

### Changes

Before, only `GUM_FILTER_TEXT_*` could be styled, this meant every line's text would look the same, even the one with the cursor on:
![pre](https://github.com/charmbracelet/gum/assets/46555942/8831e323-f753-4503-89e0-1cd5696853b5)


This PR provides a way to style `gum filter`'s cursor text through `GUM_FILTER_CURSOR_TEXT_*` environment variables as such:
![post](https://github.com/charmbracelet/gum/assets/46555942/a4d2e5b6-3358-41ef-a5fe-71f14d574860)

I tried to stick to your naming conventions, feel free to rename `CURSOR_TEXT` if you feel like it doesn't match the rest of the project.

Thanks for making `gum`, I really enjoy the added interactivity it brings to shell scripts!