### PR TITLE
Switch to termenv.EnvColorProfile()

### DIFF
--- a/format/formats.go
+++ b/format/formats.go
@@ -54,7 +54,7 @@ func markdown(input string, theme string) (string, error) {
 }
 
 func template(input string) (string, error) {
-	f := termenv.TemplateFuncs(termenv.ColorProfile())
+	f := termenv.TemplateFuncs(termenv.EnvColorProfile())
 	t, err := tpl.New("tpl").Funcs(f).Parse(input)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse template: %w", err)

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 var bubbleGumPink = lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
 
 func main() {
-	lipgloss.SetColorProfile(termenv.NewOutput(os.Stderr).Profile)
+	lipgloss.SetColorProfile(termenv.NewOutput(os.Stderr).EnvColorProfile())
 
 	if Version == "" {
 		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {


### PR DESCRIPTION
This will allow users to set `NO_COLOR` and `CLICOLOR_FORCE` when they need to override the detected values.