### PR TITLE
Add `--select-if-one` flag to `choose`/`filter`.

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -35,6 +35,11 @@ func (o Options) Run() error {
 		o.Options = strings.Split(strings.TrimSuffix(input, "\n"), "\n")
 	}
 
+	if o.SelectIfOne && len(o.Options) == 1 {
+		print(o.Options[0])
+		return nil
+	}
+
 	// We don't need to display prefixes if we are only picking one option.
 	// Simply displaying the cursor is enough.
 	if o.Limit == 1 && !o.NoLimit {
@@ -141,11 +146,7 @@ func (o Options) Run() error {
 		}
 	}
 
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		fmt.Print(s.String())
-	} else {
-		fmt.Print(ansi.Strip(s.String()))
-	}
+	print(s.String())
 
 	return nil
 }
@@ -154,6 +155,14 @@ func (o Options) Run() error {
 func (o Options) BeforeReset(ctx *kong.Context) error {
 	style.HideFlags(ctx)
 	return nil
+}
+
+func print(s string) {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Print(s)
+	} else {
+		fmt.Print(ansi.Strip(s))
+	}
 }
 
 // Check if an array contains a value.

--- a/choose/command.go
+++ b/choose/command.go
@@ -146,7 +146,11 @@ func (o Options) Run() error {
 		}
 	}
 
-	print(s.String())
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Print(s.String())
+	} else {
+		fmt.Print(ansi.Strip(s.String()))
+	}
 
 	return nil
 }
@@ -155,14 +159,6 @@ func (o Options) Run() error {
 func (o Options) BeforeReset(ctx *kong.Context) error {
 	style.HideFlags(ctx)
 	return nil
-}
-
-func print(s string) {
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		fmt.Print(s)
-	} else {
-		fmt.Print(ansi.Strip(s))
-	}
 }
 
 // Check if an array contains a value.

--- a/choose/options.go
+++ b/choose/options.go
@@ -19,6 +19,7 @@ type Options struct {
 	SelectedPrefix    string        `help:"Prefix to show on selected items (hidden if limit is 1)" default:"◉ " env:"GUM_CHOOSE_SELECTED_PREFIX"`
 	UnselectedPrefix  string        `help:"Prefix to show on unselected items (hidden if limit is 1)" default:"○ " env:"GUM_CHOOSE_UNSELECTED_PREFIX"`
 	Selected          []string      `help:"Options that should start as selected" default:"" env:"GUM_CHOOSE_SELECTED"`
+	SelectIfOne       bool          `help:"Select the given option if there is only one" group:"Selection"`
 	CursorStyle       style.Styles  `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_CURSOR_"`
 	HeaderStyle       style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_CHOOSE_HEADER_"`
 	ItemStyle         style.Styles  `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`

--- a/filter/command.go
+++ b/filter/command.go
@@ -45,11 +45,11 @@ func (o Options) Run() error {
 		return errors.New("no options provided, see `gum filter --help`")
 	}
 
-	if o.SelectIfOne && len(choices) == 1 {
+	if o.SelectIfOne && len(o.Options) == 1 {
 		if isatty.IsTerminal(os.Stdout.Fd()) {
-			fmt.Print(choices[0])
+			fmt.Print(o.Options[0])
 		} else {
-			fmt.Print(ansi.Strip(choices[0]))
+			fmt.Print(ansi.Strip(o.Options[0]))
 		}
 		return nil
 	}

--- a/filter/command.go
+++ b/filter/command.go
@@ -45,6 +45,15 @@ func (o Options) Run() error {
 		return errors.New("no options provided, see `gum filter --help`")
 	}
 
+	if o.SelectIfOne && len(choices) == 1 {
+		if isatty.IsTerminal(os.Stdout.Fd()) {
+			fmt.Print(choices[0])
+		} else {
+			fmt.Print(ansi.Strip(choices[0]))
+		}
+		return nil
+	}
+
 	options := []tea.ProgramOption{tea.WithOutput(os.Stderr)}
 	if o.Height == 0 {
 		options = append(options, tea.WithAltScreen())

--- a/filter/options.go
+++ b/filter/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	IndicatorStyle        style.Styles  `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_INDICATOR_"`
 	Limit                 int           `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit               bool          `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
+	SelectIfOne           bool          `help:"Select the given option if there is only one" group:"Selection"`
 	Strict                bool          `help:"Only returns if anything matched. Otherwise return Filter" negatable:"true" default:"true" group:"Selection"`
 	SelectedPrefix        string        `help:"Character to indicate selected items (hidden if limit is 1)" default:" ◉ " env:"GUM_FILTER_SELECTED_PREFIX"`
 	SelectedPrefixStyle   style.Styles  `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_PREFIX_"`

--- a/format/formats.go
+++ b/format/formats.go
@@ -54,7 +54,7 @@ func markdown(input string, theme string) (string, error) {
 }
 
 func template(input string) (string, error) {
-	f := termenv.TemplateFuncs(termenv.EnvColorProfile())
+	f := termenv.TemplateFuncs(termenv.ColorProfile())
 	t, err := tpl.New("tpl").Funcs(f).Parse(input)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse template: %w", err)

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 var bubbleGumPink = lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
 
 func main() {
-	lipgloss.SetColorProfile(termenv.NewOutput(os.Stderr).EnvColorProfile())
+	lipgloss.SetColorProfile(termenv.NewOutput(os.Stderr).Profile)
 
 	if Version == "" {
 		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {


### PR DESCRIPTION
Fixes #396 

### Changes
- Add `--select-if-one` to `choose`, returns the only option if only one option is given
- Add `--select-if-one` to `filter`, returns the only option if only one option is given
