### PR TITLE
spin: fix isTTY check

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -46,7 +46,7 @@ func (o Options) Run() error {
 	}
 
 	if o.ShowOutput {
-		if !isTTY {
+		if isTTY {
 			_, err := os.Stdout.WriteString(m.stdout)
 			if err != nil {
 				return fmt.Errorf("failed to write to stdout: %w", err)


### PR DESCRIPTION
The isTTY check is inverted in the --show-output option for spin, so no output is shown anymore.  Fix this by correctly checking if we are a tty or not.