### PR TITLE
(fix): ShowOutput flag displays in realtime

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -47,6 +47,8 @@ func (o Options) Run() error {
 	}
 
 	if o.ShowOutput {
+		// BubbleTea writes the View() to stderr.
+		// If the program is being piped then put the accumulated output in stdout.
 		if !isTTY {
 			_, err := os.Stdout.WriteString(m.stdout)
 			if err != nil {

--- a/spin/command.go
+++ b/spin/command.go
@@ -26,6 +26,7 @@ func (o Options) Run() error {
 		title:      o.TitleStyle.ToLipgloss().Render(o.Title),
 		command:    o.Command,
 		align:      o.Align,
+		showOutput: o.ShowOutput && isTTY,
 		timeout:    o.Timeout,
 		hasTimeout: o.Timeout > 0,
 	}
@@ -46,7 +47,7 @@ func (o Options) Run() error {
 	}
 
 	if o.ShowOutput {
-		if isTTY {
+		if !isTTY {
 			_, err := os.Stdout.WriteString(m.stdout)
 			if err != nil {
 				return fmt.Errorf("failed to write to stdout: %w", err)


### PR DESCRIPTION
Fixes the `--show-output` flag not piping output.
Fixes the `--show-output` flag not showing live output.