### PR TITLE
feat(confirm): add `--show-output`

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -19,6 +19,7 @@ func (o Options) Run() error {
 	m := model{
 		affirmative:      o.Affirmative,
 		negative:         o.Negative,
+		showOutput:       o.ShowOutput,
 		confirmation:     o.Default,
 		defaultSelection: o.Default,
 		keys:             defaultKeymap(o.Affirmative, o.Negative),

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -38,6 +38,14 @@ func (o Options) Run() error {
 		return fmt.Errorf("unable to confirm: %w", err)
 	}
 
+	if o.ShowOutput {
+		confirmationText := m.negative
+		if m.confirmation {
+			confirmationText = m.affirmative
+		}
+		fmt.Println(m.prompt, confirmationText)
+	}
+
 	m = tm.(model)
 	if m.confirmation {
 		return nil

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -82,6 +82,7 @@ type model struct {
 	help        help.Model
 	keys        keymap
 
+	showOutput   bool
 	confirmation bool
 
 	defaultSelection bool

--- a/confirm/options.go
+++ b/confirm/options.go
@@ -9,6 +9,7 @@ import (
 // Options is the customization options for the confirm command.
 type Options struct {
 	Default     bool   `help:"Default confirmation action" default:"true"`
+	ShowOutput  bool   `help:"Print prompt and chosen action to output" default:"false"`
 	Affirmative string `help:"The title of the affirmative action" default:"Yes"`
 	Negative    string `help:"The title of the negative action" default:"No"`
 	Prompt      string `arg:"" help:"Prompt to display." default:"Are you sure?"`


### PR DESCRIPTION
Fixes nothing, this is a feature I found missing from a specific use case I had in mind.

### Changes

Adds the `--show-output` flag to `gum confirm` which prints the prompt and the chosen action to STDOUT.

```shell
gum confirm --show-output 'Do you agree?'
# Do you agree? Yes

gum confirm --show-output 'Do you agree?'
# Do you agree? No
# exit status 1
``` 

This merge adds 2 commits, only the first one (`4f9235b`) is required for the feature to work.
Since the feature doesn't affect `confirm/confirm.go` I feel like the second (`432182f`) isn't necessary, but I still included it in case I misunderstood the purpose of the model structure.