### PR TITLE
feat(write): ESC should be successful

### DIFF
--- a/write/write.go
+++ b/write/write.go
@@ -46,11 +46,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc":
+		case "ctrl+c":
 			m.aborted = true
 			m.quitting = true
 			return m, tea.Quit
-		case "ctrl+d":
+		case "ctrl+d", "esc":
 			m.quitting = true
 			return m, tea.Quit
 		}


### PR DESCRIPTION
Change ESC from aborting to successful quitting.

'vi' users press ESC as an uncontrollable tick, making using 'gum write' painful when all their work is lost.

I'm floating this as an idea.

I could add a non-zero exit code, mostly preserving the current behavior.  If I did that, ctrl-c should also return the text.

If we standardized the exit code, we could apply it to #286.

### Changes

- ESC now indicates a normal exit (like pressing CTRL+D).
