### PR TITLE
fix(input): Avoid reading from stdin if `--value` is being used

### DIFF
--- a/input/command.go
+++ b/input/command.go
@@ -18,10 +18,10 @@ import (
 // https://github.com/charmbracelet/bubbles/textinput
 func (o Options) Run() error {
 	i := textinput.New()
-	if in, _ := stdin.Read(); in != "" && o.Value == "" {
-		i.SetValue(in)
-	} else {
+	if o.Value != "" {
 		i.SetValue(o.Value)
+	} else if in, _ := stdin.Read(); in != "" {
+		i.SetValue(in)
 	}
 
 	i.Focus()


### PR DESCRIPTION
Currently, `gum input` reads from stdin even if we set a value with the `--value` flag. This can cause some issues if we are piping a script into a shell (`$ cat script.sh | bash`) as seen in #447.

### Changes

- If the `--value` is being used `gum input` would not read from stdin.
