### PR TITLE
Hide Style Flags consistently

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/paginator"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -16,7 +15,6 @@ import (
 	"github.com/charmbracelet/gum/ansi"
 	"github.com/charmbracelet/gum/internal/exit"
 	"github.com/charmbracelet/gum/internal/stdin"
-	"github.com/charmbracelet/gum/style"
 )
 
 var (
@@ -147,12 +145,6 @@ func (o Options) Run() error {
 		fmt.Print(ansi.Strip(s.String()))
 	}
 
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }
 

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -6,10 +6,7 @@ import (
 
 	"github.com/charmbracelet/gum/internal/exit"
 
-	"github.com/alecthomas/kong"
 	tea "github.com/charmbracelet/bubbletea"
-
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run provides a shell script interface for prompting a user to confirm an
@@ -40,11 +37,5 @@ func (o Options) Run() error {
 
 	os.Exit(1)
 
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }

--- a/file/command.go
+++ b/file/command.go
@@ -8,10 +8,8 @@ import (
 
 	"github.com/charmbracelet/gum/internal/exit"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/filepicker"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run is the interface to picking a file.
@@ -70,11 +68,5 @@ func (o Options) Run() error {
 
 	fmt.Println(m.selectedPath)
 
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }

--- a/filter/command.go
+++ b/filter/command.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,7 +16,6 @@ import (
 	"github.com/charmbracelet/gum/internal/exit"
 	"github.com/charmbracelet/gum/internal/files"
 	"github.com/charmbracelet/gum/internal/stdin"
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run provides a shell script interface for filtering through options, powered
@@ -131,10 +129,4 @@ func (o Options) checkSelected(m model, isTTY bool) {
 			fmt.Println(ansi.Strip(k))
 		}
 	}
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
-	return nil
 }

--- a/input/command.go
+++ b/input/command.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/charmbracelet/gum/cursor"
 	"github.com/charmbracelet/gum/internal/exit"
 	"github.com/charmbracelet/gum/internal/stdin"
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run provides a shell script interface for the text input bubble.
@@ -58,11 +56,5 @@ func (o Options) Run() error {
 	}
 
 	fmt.Println(m.textinput.Value())
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }

--- a/log/options.go
+++ b/log/options.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/gum/style"
 )
 
@@ -24,10 +23,4 @@ type Options struct {
 	KeyStyle       style.Styles `embed:"" prefix:"key." help:"The style of the key" set:"defaultFaint=true" envprefix:"GUM_LOG_KEY_"`
 	ValueStyle     style.Styles `embed:"" prefix:"value." help:"The style of the value" envprefix:"GUM_LOG_VALUE_"`
 	SeparatorStyle style.Styles `embed:"" prefix:"separator." help:"The style of the separator" set:"defaultFaint=true" envprefix:"GUM_LOG_SEPARATOR_"`
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -48,8 +48,9 @@ func main() {
 		kong.Description(fmt.Sprintf("A tool for %s shell scripts.", bubbleGumPink.Render("glamorous"))),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
-			Compact: true,
-			Summary: false,
+			Compact:             true,
+			Summary:             false,
+			NoExpandSubcommands: true,
 		}),
 		kong.Vars{
 			"version":                 version,
@@ -74,7 +75,6 @@ func main() {
 		if errors.Is(err, exit.ErrAborted) {
 			os.Exit(exit.StatusAborted)
 		}
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/pager/command.go
+++ b/pager/command.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/gum/internal/stdin"
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run provides a shell script interface for the viewport bubble.
@@ -48,11 +46,5 @@ func (o Options) Run() error {
 	if err != nil {
 		return fmt.Errorf("unable to start program: %w", err)
 	}
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }

--- a/spin/command.go
+++ b/spin/command.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-isatty"
 
 	"github.com/charmbracelet/gum/internal/exit"
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run provides a shell script interface for the spinner bubble.
@@ -55,11 +53,5 @@ func (o Options) Run() error {
 	}
 
 	os.Exit(m.status)
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }

--- a/style/command.go
+++ b/style/command.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/gum/internal/stdin"
 )
 
@@ -29,20 +28,4 @@ func (o Options) Run() error {
 	}
 	fmt.Println(o.Style.ToLipgloss().Render(text))
 	return nil
-}
-
-// HideFlags hides the flags from the usage output. This is used in conjunction
-// with BeforeReset hook.
-func HideFlags(ctx *kong.Context) {
-	n := ctx.Selected()
-	if n == nil {
-		return
-	}
-	for _, f := range n.Flags {
-		if g := f.Group; g != nil && g.Key == groupName {
-			if !strings.HasSuffix(f.Name, ".foreground") {
-				f.Hidden = true
-			}
-		}
-	}
 }

--- a/style/lipgloss.go
+++ b/style/lipgloss.go
@@ -26,3 +26,24 @@ func (s Styles) ToLipgloss() lipgloss.Style {
 		Strikethrough(s.Strikethrough).
 		Underline(s.Underline)
 }
+
+// ToLipgloss takes a Styles flag set and returns the corresponding
+// lipgloss.Style.
+func (s StylesNotHidden) ToLipgloss() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Background(lipgloss.Color(s.Background)).
+		Foreground(lipgloss.Color(s.Foreground)).
+		BorderBackground(lipgloss.Color(s.BorderBackground)).
+		BorderForeground(lipgloss.Color(s.BorderForeground)).
+		Align(decode.Align[s.Align]).
+		Border(Border[s.Border]).
+		Height(s.Height).
+		Width(s.Width).
+		Margin(parseMargin(s.Margin)).
+		Padding(parsePadding(s.Padding)).
+		Bold(s.Bold).
+		Faint(s.Faint).
+		Italic(s.Italic).
+		Strikethrough(s.Strikethrough).
+		Underline(s.Underline)
+}

--- a/style/options.go
+++ b/style/options.go
@@ -42,6 +42,10 @@ type Styles struct {
 }
 
 // StylesNotHidden allows the style struct to display full help when not-embedded.
+//
+// NB: We must duplicate this struct to ensure that `gum style` does not hide
+// flags when an error pops up. Ideally, we can dynamically hide or show flags
+// based on the command run: https://github.com/alecthomas/kong/issues/316
 type StylesNotHidden struct {
 	// Colors
 	Foreground string `help:"Foreground Color" default:"${defaultForeground}" group:"Style Flags" env:"FOREGROUND"`

--- a/style/options.go
+++ b/style/options.go
@@ -6,8 +6,8 @@ const (
 
 // Options is the customization options for the style command.
 type Options struct {
-	Text  []string `arg:"" optional:"" help:"Text to which to apply the style"`
-	Style Styles   `embed:""`
+	Text  []string        `arg:"" optional:"" help:"Text to which to apply the style"`
+	Style StylesNotHidden `embed:""`
 }
 
 // Styles is a flag set of possible styles.
@@ -18,8 +18,34 @@ type Options struct {
 // components, through embedding and prefixing.
 type Styles struct {
 	// Colors
-	Background string `help:"Background Color" default:"${defaultBackground}" group:"Style Flags" env:"BACKGROUND"`
 	Foreground string `help:"Foreground Color" default:"${defaultForeground}" group:"Style Flags" env:"FOREGROUND"`
+	Background string `help:"Background Color" default:"${defaultBackground}" group:"Style Flags" env:"BACKGROUND" hidden:"true"`
+
+	// Border
+	Border           string `help:"Border Style" enum:"none,hidden,normal,rounded,thick,double" default:"${defaultBorder}" group:"Style Flags" env:"BORDER" hidden:"true"`
+	BorderBackground string `help:"Border Background Color" group:"Style Flags" default:"${defaultBorderBackground}" env:"BORDER_BACKGROUND" hidden:"true"`
+	BorderForeground string `help:"Border Foreground Color" group:"Style Flags" default:"${defaultBorderForeground}" env:"BORDER_FOREGROUND" hidden:"true"`
+
+	// Layout
+	Align   string `help:"Text Alignment" enum:"left,center,right,bottom,middle,top" default:"${defaultAlign}" group:"Style Flags" env:"ALIGN" hidden:"true"`
+	Height  int    `help:"Text height" default:"${defaultHeight}" group:"Style Flags" env:"HEIGHT" hidden:"true"`
+	Width   int    `help:"Text width" default:"${defaultWidth}" group:"Style Flags" env:"WIDTH" hidden:"true"`
+	Margin  string `help:"Text margin" default:"${defaultMargin}" group:"Style Flags" env:"MARGIN" hidden:"true"`
+	Padding string `help:"Text padding" default:"${defaultPadding}" group:"Style Flags" env:"PADDING" hidden:"true"`
+
+	// Format
+	Bold          bool `help:"Bold text" default:"${defaultBold}" group:"Style Flags" env:"BOLD" hidden:"true"`
+	Faint         bool `help:"Faint text" default:"${defaultFaint}" group:"Style Flags" env:"FAINT" hidden:"true"`
+	Italic        bool `help:"Italicize text" default:"${defaultItalic}" group:"Style Flags" env:"ITALIC" hidden:"true"`
+	Strikethrough bool `help:"Strikethrough text" default:"${defaultStrikethrough}" group:"Style Flags" env:"STRIKETHROUGH" hidden:"true"`
+	Underline     bool `help:"Underline text" default:"${defaultUnderline}" group:"Style Flags" env:"UNDERLINE" hidden:"true"`
+}
+
+// StylesNotHidden allows the style struct to display full help when not-embedded.
+type StylesNotHidden struct {
+	// Colors
+	Foreground string `help:"Foreground Color" default:"${defaultForeground}" group:"Style Flags" env:"FOREGROUND"`
+	Background string `help:"Background Color" default:"${defaultBackground}" group:"Style Flags" env:"BACKGROUND"`
 
 	// Border
 	Border           string `help:"Border Style" enum:"none,hidden,normal,rounded,thick,double" default:"${defaultBorder}" group:"Style Flags" env:"BORDER"`

--- a/table/command.go
+++ b/table/command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -129,11 +128,5 @@ func (o Options) Run() error {
 
 	writer.Flush()
 
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }

--- a/write/command.go
+++ b/write/command.go
@@ -5,14 +5,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/charmbracelet/gum/cursor"
 	"github.com/charmbracelet/gum/internal/exit"
 	"github.com/charmbracelet/gum/internal/stdin"
-	"github.com/charmbracelet/gum/style"
 )
 
 // Run provides a shell script interface for the text area bubble.
@@ -66,11 +64,5 @@ func (o Options) Run() error {
 	}
 
 	fmt.Println(m.textarea.Value())
-	return nil
-}
-
-// BeforeReset hook. Used to unclutter style flags.
-func (o Options) BeforeReset(ctx *kong.Context) error {
-	style.HideFlags(ctx)
 	return nil
 }


### PR DESCRIPTION
Prevents style flags from leaking through when a user makes an error in the usage.

For example:


```
gum write --help
```

using the `--help` flag produces a different usage than the user making an error with the flags.

```
gum write --error
```

This is because we perform the hiding of the flags on `BeforeReset` which is called for the help flag but not on an error.

The downside of this approach is that we must duplicate the style struct so that we can maintain a fully hidden embeddable struct while also having a non-hidden struct so the style command has proper usage / help / errors.

This can be resolve once the following issue is implemented:

https://github.com/alecthomas/kong/issues/316