### PR TITLE
Add newline printing to --select-if-one

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -35,6 +35,7 @@ func (o Options) Run() error {
 
 	if o.SelectIfOne && len(o.Options) == 1 {
 		print(o.Options[0])
+		print("\n")
 		return nil
 	}
 

--- a/filter/command.go
+++ b/filter/command.go
@@ -49,6 +49,7 @@ func (o Options) Run() error {
 		} else {
 			fmt.Print(ansi.Strip(o.Options[0]))
 		}
+		print("\n")
 		return nil
 	}
 


### PR DESCRIPTION
This matches how choose works normally when there are more than
one option.
