### PR TITLE
fix(Spin): Output Pipes if Timeout Occurs

### DIFF
--- a/spin/spin.go
+++ b/spin/spin.go
@@ -102,6 +102,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case timeout.TickTimeoutMsg:
 		if msg.TimeoutValue <= 0 {
+			// grab current output before closing for piped instances
+			m.stdout = outbuf.String()
+
 			m.status = exit.StatusAborted
 			return m, tea.Quit
 		}


### PR DESCRIPTION
Fixes the `--show-output` flag from not working if the program is piped and ended by timeout (`--timeout`)

### Changes
- Stores output buffer within the model once the timeout is procced
