### PR TITLE
fix: Make --select-if-one print to stdout

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -34,8 +34,7 @@ func (o Options) Run() error {
 	}
 
 	if o.SelectIfOne && len(o.Options) == 1 {
-		print(o.Options[0])
-		print("\n")
+		fmt.Println(o.Options[0])
 		return nil
 	}
 

--- a/filter/command.go
+++ b/filter/command.go
@@ -44,12 +44,7 @@ func (o Options) Run() error {
 	}
 
 	if o.SelectIfOne && len(o.Options) == 1 {
-		if isatty.IsTerminal(os.Stdout.Fd()) {
-			fmt.Print(o.Options[0])
-		} else {
-			fmt.Print(ansi.Strip(o.Options[0]))
-		}
-		print("\n")
+		fmt.Println(o.Options[0])
 		return nil
 	}
 


### PR DESCRIPTION
For some reason it wasn't printing to stdout (and I could repro that
bug even on versions before I added the newline). It was only showing
up on other streams in the shell (error stream probably), not getting
sent into pipes.

I changed it to fmt.Println.

As for the ansi-stripping that was in `filter`, LMK if that's what you
prefer and I'll add it to `choose` too. I just wanted them to match.
