### PR TITLE
docs: add openSUSE installation instructions for gum

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ gpgcheck=1
 gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
 sudo yum install gum
 
+# openSUSE (zypper)
+echo '[charm]
+name=Charm
+baseurl=https://repo.charm.sh/yum/
+enabled=1
+type=rpm-md
+gpgcheck=1
+gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/zypp/repos.d/charm.repo
+sudo rpm --import https://repo.charm.sh/yum/gpg.key
+sudo zypper refresh
+sudo zypper install gum
+
 # Alpine
 apk add gum
 


### PR DESCRIPTION
This commit introduces installation instructions for the gum tool in the README.md, tailored explicitly for openSUSE users. It includes steps for adding the Charm repository and installing gum using Zypper. This update ensures that openSUSE users have clear guidance on installing gum, aligning with the existing documentation for other operating systems.

### Changes
- Add documentation in the `README.md` to include how to install using zypper
