### PR TITLE
build: rename scoop to charm-gum

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ includes:
 
 variables:
   main: "."
+  scoop_name: charm-gum
   description: "A tool for glamorous shell scripts"
   github_url: "https://github.com/charmbracelet/gum"
   maintainer: "Maas Lalani <maas@charm.sh>"


### PR DESCRIPTION
gum conflicts with another tool, even if it is in our own bucket, this still makes it difficult to install.

the official scoop for gum is also called charm-gum, so I think this should work better.

refs https://github.com/charmbracelet/scoop-bucket/pull/7
