### PR TITLE
feat(spin): Add support for --show-error for the spinner. (rebase #440)

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -44,8 +44,8 @@ func (o Options) Run() error {
 		return fmt.Errorf("failed to access stdout: %w", err)
 	}
 
-	// If the command succeed, and we are printing output and we are in a TTY then push the STDOUT we got
-	// to the actual STDOUT for piping or other things.
+	// If the command succeeds, and we are printing output and we are in a TTY then push the STDOUT we got to the actual
+	// STDOUT for piping or other things.
 	if m.status == 0 {
 		if o.ShowOutput {
 			// BubbleTea writes the View() to stderr.

--- a/spin/options.go
+++ b/spin/options.go
@@ -11,6 +11,7 @@ type Options struct {
 	Command []string `arg:"" help:"Command to run"`
 
 	ShowOutput   bool          `help:"Show or pipe output of command during execution" default:"false" env:"GUM_SPIN_SHOW_OUTPUT"`
+	ShowError    bool          `help:"Show output of command only if the command fails" default:"false" env:"GUM_SPIN_SHOW_ERROR"`
 	Spinner      string        `help:"Spinner type" short:"s" type:"spinner" enum:"line,dot,minidot,jump,pulse,points,globe,moon,monkey,meter,hamburger" default:"dot" env:"GUM_SPIN_SPINNER"`
 	SpinnerStyle style.Styles  `embed:"" prefix:"spinner." set:"defaultForeground=212" envprefix:"GUM_SPIN_SPINNER_"`
 	Title        string        `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`


### PR DESCRIPTION
This is #440 but rebased so it can be merged easily. Thanks @elliotcourant for making the actual changes!

> This makes it so that if the `--show-error` flag is provided then the full output of the command will be printed if the command fails. This kind of works in conjuncture with `--show-output` in that if the command succeeds only STDOUT is pushed. If the command fails both `STDOUT` and `STDERR` are pushed.
> 
> This builds off of #371
> 
> Resolves #55
> 
> Fixes #55
> 
> ### Changes
> * Adds support for a `--show-error` flag for the spinner command.
> 
> ### Examples
> ```shell
> gum spin -s minidot --show-error -- bash -c "sleep 1 && echo 'you can see me if the command fails' && exit 1"
> # you can see me if the command fails
> # exit status 1
> ```
> 
> ```shell
> gum spin -s minidot --show-error -- bash -c "sleep 1 && echo 'you can see me if the command fails' && exit 0"
> # (no output)
> ```
