### PR TITLE
Replace custom strings with constants from the standard library

### DIFF
--- a/log/command.go
+++ b/log/command.go
@@ -46,9 +46,9 @@ func (o Options) Run() error {
 		"stampmilli":  time.StampMilli,
 		"stampmicro":  time.StampMicro,
 		"stampnano":   time.StampNano,
-		"datetime":    "2006-01-02 15:04:05",
-		"dateonly":    "2006-01-02",
-		"timeonly":    "15:04:05",
+		"datetime":    time.DateTime,
+		"dateonly":    time.DateOnly,
+		"timeonly":    time.TimeOnly,
 	}
 
 	tf, ok := timeFormats[strings.ToLower(o.Time)]


### PR DESCRIPTION
In the go 1.21 required by the project, these constants are already built-in in the standard library. So we can replace it and make code more elegant