### PR TITLE
434 Add Command to Tail -n Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ go install github.com/charmbracelet/gum@latest
   * [`spin`](#spin): Display spinner while running a command
   * [`style`](#style): Apply coloring, borders, spacing to text
   * [`table`](#table): Render a table of data
+  * [`tail`](#tail): Provides a means of streaming -n of lines from stdin
   * [`write`](#write): Prompt for long-form text
   * [`log`](#log): Log messages to output
 
@@ -261,6 +262,14 @@ gum style \
 ```
 
 <img src="https://github.com/charmbracelet/gum/assets/42545625/67468acf-b3e0-4e78-bd89-360739eb44fa" width="600" alt="Bubble Gum, So sweet and so fresh!" />
+
+## Tail
+
+Render a subset of lines from stdin for easy log monitoring without cluttering the terminal output.
+
+```bash
+{ sudo apt update -y && sudo apt upgrade -y && sudo apt autoremove -y; } | gum tail -n 3
+```
 
 ## Join
 

--- a/gum.go
+++ b/gum.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/gum/spin"
 	"github.com/charmbracelet/gum/style"
 	"github.com/charmbracelet/gum/table"
+	"github.com/charmbracelet/gum/tail"
 	"github.com/charmbracelet/gum/write"
 )
 
@@ -195,6 +196,13 @@ type Gum struct {
 	//  Cherry      $0.75
 	//
 	Table table.Options `cmd:"" help:"Render a table of data"`
+
+	// Tail
+	// Provides a means of streaming -n of lines from stdin
+	// Useful for showing a subset of output from a process without clogging up the terminal
+	//
+	// $ { sudo apt update -y && sudo apt upgrade -y && sudo apt autoremove -y; } | gum tail -n 3
+	Tail tail.Options `cmd:"" help:"Tail the -n of lines from stdin"`
 
 	// Write provides a shell script interface for the text area bubble.
 	// https://github.com/charmbracelet/bubbles/tree/master/textarea

--- a/tail/command.go
+++ b/tail/command.go
@@ -1,0 +1,10 @@
+package tail
+
+import (
+	"fmt"
+)
+
+func (o Options) Run() error {
+	fmt.Println("tail")
+	return nil
+}

--- a/tail/command.go
+++ b/tail/command.go
@@ -1,10 +1,62 @@
 package tail
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 )
 
+// Run executes the tail command
 func (o Options) Run() error {
-	fmt.Println("tail")
-	return nil
+    // Channel to communicate lines read from stdin
+    lines := make(chan string)
+
+    // Read from stdin in a separate goroutine
+    go func() {
+        scanner := bufio.NewScanner(os.Stdin)
+        for scanner.Scan() {
+            lines <- scanner.Text()
+        }
+        close(lines)
+    }()
+
+    // Slice to store the last n lines
+    lastLines := make([]string, 0, o.NumLines)
+
+    // Continuously read lines from stdin and update the last n lines
+    for line := range lines {
+        lastLines = appendLine(lastLines, line, o.NumLines)
+        clearScreen()
+        printLines(lastLines, o.NumLines)
+    }
+
+    return nil
+}
+
+// appendLine appends a line to the slice, maintaining the maximum number of lines.
+func appendLine(lines []string, line string, maxLines int) []string {
+    lines = append(lines, line)
+    if len(lines) > maxLines {
+        lines = lines[1:]
+    }
+    return lines
+}
+
+func clearScreen() {
+    fmt.Print("\033[H\033[2J")
+}
+
+// printLines prints the last n lines to stdout
+func printLines(lines []string, n int) {
+    // Print an extra newline for separation of previous shell output and the tailing
+	fmt.Println()
+
+    // Print the last n lines
+    start := len(lines) - n
+    if start < 0 {
+        start = 0
+    }
+    for i := start; i < len(lines); i++ {
+        fmt.Println(lines[i])
+    }
 }

--- a/tail/options.go
+++ b/tail/options.go
@@ -1,0 +1,3 @@
+package tail
+
+type Options struct {}

--- a/tail/options.go
+++ b/tail/options.go
@@ -1,3 +1,5 @@
 package tail
 
-type Options struct {}
+type Options struct {
+	NumLines	int		`short:"n" default:"4" help:"Number of lines you want to tail"`
+}


### PR DESCRIPTION
Closes #434

### Changes
- Adds a new `gum tail` subcommand
- Allows user to stream stdin for -n number of lines
- Keeps logs from piped running processes from cluttering up the terminal

### Example
```bash
{ sudo apt update -y && sudo apt upgrade -y && sudo apt autoremove -y; } | gum tail -n 3 // Stream the last 3 lines of info generated by this process until complete
```
