### PR TITLE
Support using the Home/End keys in pager

### DIFF
--- a/pager/pager.go
+++ b/pager/pager.go
@@ -120,9 +120,9 @@ func (m model) KeyHandler(key tea.KeyMsg) (model, func() tea.Msg) {
 		}
 	} else {
 		switch key.String() {
-		case "g":
+		case "g", "home":
 			m.viewport.GotoTop()
-		case "G":
+		case "G", "end":
 			m.viewport.GotoBottom()
 		case "/":
 			m.search.Begin()


### PR DESCRIPTION
Since `choose` also supports Home/End for navigation in https://github.com/charmbracelet/gum/issues/393.
It would be nice if `pager` can do the same.