### PR TITLE
fix(stdin): add trim of trailing newline

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -22,7 +22,7 @@ func (o Options) Run() error {
 		if input == "" {
 			return errors.New("no options provided, see `gum choose --help`")
 		}
-		o.Options = strings.Split(strings.TrimSuffix(input, "\n"), "\n")
+		o.Options = strings.Split(input, "\n")
 	}
 
 	if o.SelectIfOne && len(o.Options) == 1 {

--- a/filter/command.go
+++ b/filter/command.go
@@ -34,7 +34,7 @@ func (o Options) Run() error {
 
 	if len(o.Options) == 0 {
 		if input, _ := stdin.Read(); input != "" {
-			o.Options = strings.Split(strings.TrimSuffix(input, "\n"), "\n")
+			o.Options = strings.Split(input, "\n")
 		} else {
 			o.Options = files.List()
 		}

--- a/internal/stdin/stdin.go
+++ b/internal/stdin/stdin.go
@@ -28,7 +28,7 @@ func Read() (string, error) {
 		}
 	}
 
-	return b.String(), nil
+	return strings.TrimSuffix(b.String(), "\n"), nil
 }
 
 // IsEmpty returns whether stdin is empty.

--- a/style/command.go
+++ b/style/command.go
@@ -24,7 +24,6 @@ func (o Options) Run() error {
 		if text == "" {
 			return errors.New("no input provided, see `gum style --help`")
 		}
-		text = strings.TrimSuffix(text, "\n")
 	}
 	fmt.Println(o.Style.ToLipgloss().Render(text))
 	return nil


### PR DESCRIPTION
Fixes #573

### Changes
- When receiving inputs via stdin trim the trailing newline.
- Removed trimsuffix from other commands where stdin was read.
