### PR TITLE
Add flox as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ pacman -S gum
 # Nix
 nix-env -iA nixpkgs.gum
 
+# Flox
+flox install gum
+
 # Windows (via WinGet or Scoop)
 winget install charmbracelet.gum
 scoop install charm-gum


### PR DESCRIPTION
`gum` is available and seems to work in [Flox](https://flox.dev/docs/) today.
Since Flox is closely related to Nix, it made sense to me to add it below the existing Nix install instructions. 😊

### Changes
- Add Flox to the list of installation options in `README.md`
