### PR TITLE
Add key/value feature for `gum choose` (#530)

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -39,7 +39,9 @@ func (o Options) Run() error {
 		if delimIndex == -1 {
 			options[i] = huh.NewOption(option, option)
 		} else {
-			options[i] = huh.NewOption(option[:delimIndex], option[delimIndex+1:])
+			key := strings.TrimSpace(option[:delimIndex])
+			value := strings.TrimSpace(option[delimIndex+1:])
+			options[i] = huh.NewOption(key, value)
 		}
 	}
 

--- a/choose/command.go
+++ b/choose/command.go
@@ -35,13 +35,13 @@ func (o Options) Run() error {
 	theme := huh.ThemeCharm()
 	options := make([]huh.Option[string], len(o.Options))
 	for i, option := range o.Options {
-		delimIndex := strings.Index(option, o.Deliminator)
-		if delimIndex == -1 {
-			options[i] = huh.NewOption(option, option)
-		} else {
-			key := strings.TrimSpace(option[:delimIndex])
-			value := strings.TrimSpace(option[delimIndex+1:])
+		parsed := strings.SplitN(option, o.Deliminator, 2)
+		if len(parsed) == 2 {
+			key := strings.TrimSpace(parsed[0])
+			value := strings.TrimSpace(parsed[1])
 			options[i] = huh.NewOption(key, value)
+		} else {
+			options[i] = huh.NewOption(option, option)
 		}
 	}
 

--- a/choose/command.go
+++ b/choose/command.go
@@ -33,7 +33,15 @@ func (o Options) Run() error {
 	}
 
 	theme := huh.ThemeCharm()
-	options := huh.NewOptions(o.Options...)
+	options := make([]huh.Option[string], len(o.Options))
+	for i, option := range o.Options {
+		delimIndex := strings.Index(option, o.Deliminator)
+		if delimIndex == -1 {
+			options[i] = huh.NewOption(option, option)
+		} else {
+			options[i] = huh.NewOption(option[:delimIndex], option[delimIndex+1:])
+		}
+	}
 
 	theme.Focused.Base = lipgloss.NewStyle()
 	theme.Focused.Title = o.HeaderStyle.ToLipgloss()

--- a/choose/options.go
+++ b/choose/options.go
@@ -26,4 +26,5 @@ type Options struct {
 	ItemStyle         style.Styles  `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`
 	SelectedItemStyle style.Styles  `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_"`
 	Timeout           time.Duration `help:"Timeout until choose returns selected element" default:"0" env:"GUM_CCHOOSE_TIMEOUT"` // including timeout command options [Timeout,...]
+	Deliminator       string        `help:"Deliminator to split the options to keys and values" default:"=" env:"GUM_CHOOSE_DELIMINATOR"`
 }


### PR DESCRIPTION
Fixes #530

### Changes
- Use huh to implement custom `gum choose` key and value.

