### PR TITLE
chore(readme): add repo installation instructions for DEBs and RPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ winget install charmbracelet.gum
 scoop install charm-gum
 ```
 
+<details>
+<summary>Debian/Ubuntu</summary>
+
+```bash
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
+sudo apt update && sudo apt install gum
+```
+</details>
+
+<details>
+<summary>Fedora/RHEL</summary>
+
+```bash
+echo '[charm]
+name=Charm
+baseurl=https://repo.charm.sh/yum/
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
+sudo yum install gum
+```
+</details>
+
 Or download it:
 
 * [Packages][releases] are available in Debian, RPM, and Alpine formats

--- a/man/command.go
+++ b/man/command.go
@@ -18,7 +18,7 @@ func (m Man) BeforeApply(ctx *kong.Context) error {
 	man := mangokong.NewManPage(1, ctx.Model)
 	man = man.WithSection("Copyright", "(C) 2022-2023 Charmbracelet, Inc.\n"+
 		"Released under MIT license.")
-	fmt.Fprint(ctx.Stdout, man.Build(roff.NewDocument()))
+	_, _ = fmt.Fprint(ctx.Stdout, man.Build(roff.NewDocument()))
 	ctx.Exit(0)
 	return nil
 }


### PR DESCRIPTION
I added them in little toggly things to keep the installation instructions section short.