### PR TITLE
chore: remove explicitly defined max functions

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -332,10 +332,3 @@ func clamp(min, max, val int) int {
 	}
 	return val
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/timeout/options.go
+++ b/timeout/options.go
@@ -46,10 +46,3 @@ func Tick(timeoutValue time.Duration, data interface{}) tea.Cmd {
 func Str(timeout time.Duration) string {
 	return fmt.Sprintf(" (%d)", max(0, int(timeout.Seconds())))
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Fixes nil

### Changes
- Removes explicitly defined max functions from filter and timeout because they are a native part of Go since 1.21.