### PR TITLE
Add binding for escape key to `file` command

### DIFF
--- a/file/command.go
+++ b/file/command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -31,6 +32,7 @@ func (o Options) Run() error {
 	theme.Focused.SelectedOption = o.SelectedStyle.ToLipgloss()
 
 	keymap := huh.NewDefaultKeyMap()
+	keymap.Quit = key.NewBinding(key.WithKeys("ctrl+c", "esc"))
 	keymap.FilePicker.Open.SetEnabled(false)
 
 	// XXX: These should be file selected specific.


### PR DESCRIPTION
Fixes #626.

### Changes

- Add `esc` key binding (and preserve existing `ctrl+c` binding) to the `file` command
