### PR TITLE
revert: "add key/value feature for `gum choose` (#530)"

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -33,17 +33,7 @@ func (o Options) Run() error {
 	}
 
 	theme := huh.ThemeCharm()
-	options := make([]huh.Option[string], len(o.Options))
-	for i, option := range o.Options {
-		parsed := strings.SplitN(option, o.Deliminator, 2)
-		if len(parsed) == 2 {
-			key := strings.TrimSpace(parsed[0])
-			value := strings.TrimSpace(parsed[1])
-			options[i] = huh.NewOption(key, value)
-		} else {
-			options[i] = huh.NewOption(option, option)
-		}
-	}
+	options := huh.NewOptions(o.Options...)
 
 	theme.Focused.Base = lipgloss.NewStyle()
 	theme.Focused.Title = o.HeaderStyle.ToLipgloss()

--- a/choose/options.go
+++ b/choose/options.go
@@ -26,5 +26,4 @@ type Options struct {
 	ItemStyle         style.Styles  `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`
 	SelectedItemStyle style.Styles  `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_"`
 	Timeout           time.Duration `help:"Timeout until choose returns selected element" default:"0" env:"GUM_CCHOOSE_TIMEOUT"` // including timeout command options [Timeout,...]
-	Deliminator       string        `help:"Deliminator to split the options to keys and values" default:"=" env:"GUM_CHOOSE_DELIMINATOR"`
 }


### PR DESCRIPTION
Reverts charmbracelet/gum#598 due to a typo. We can fix the typo and re-add this, but after the next release which is purely a bugfix release.