### PR TITLE
revert: "added timeout option to choose and other patches (maybe) (#6…

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -86,7 +86,6 @@ func (o Options) Run() error {
 			WithWidth(width).
 			WithShowHelp(o.ShowHelp).
 			WithTheme(theme).
-			WithTimeout(o.Timeout).
 			Run()
 		if err != nil {
 			return err
@@ -112,7 +111,6 @@ func (o Options) Run() error {
 		WithWidth(width).
 		WithTheme(theme).
 		WithShowHelp(o.ShowHelp).
-		WithTimeout(o.Timeout).
 		Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
This reverts commit 1d07efda84d077b4ff259ebd88860105c936d6c1.

We're reverting this due to a bug where timeout is printed on timeout. Additonally:

* This should also default to seconds when no unit is specified (i.e. `--timeout=5`)
* We should show a timeout indicator in the UI

We'll address these and re-add this after the next release.