### PR TITLE
feat: allow cursor option in file

### DIFF
--- a/file/command.go
+++ b/file/command.go
@@ -42,6 +42,7 @@ func (o Options) Run() error {
 			huh.NewFilePicker().
 				Picking(true).
 				CurrentDirectory(path).
+				Cursor(o.Cursor).
 				DirAllowed(o.Directory).
 				FileAllowed(o.File).
 				Height(o.Height).


### PR DESCRIPTION
Fixes [#662](https://github.com/charmbracelet/gum/issues/662)

Please see the related [issue](https://github.com/charmbracelet/huh/issues/399) in [huh](https://github.com/charmbracelet/huh). 

### Changes
- Allow `cursor` option in the file picker.

