### PR TITLE
examples/test.sh: Fixes broken table example

### DIFF
--- a/examples/test.sh
+++ b/examples/test.sh
@@ -43,7 +43,7 @@ gum write
 gum write --width 40 --height 6 --placeholder "Type whatever you want" --prompt "| " --show-cursor-line --show-line-numbers --value "Something..." --base.padding 1 --cursor.foreground 99 --prompt.foreground 99
 
 # Table
-gum table < table/example.csv
+gum table --height 12 < ../table/example.csv
 
 # Pager
 gum pager < README.md


### PR DESCRIPTION
Fixes broken portion of examples/test.sh due to incorrect path to CSV. Also adds a `--height=12` to work around current bug where height is set to 0 if not specified.