### PR TITLE
fix(confirm) `--timeout` was ignored, now works as documented

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -1,6 +1,7 @@
 package confirm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -32,9 +33,7 @@ func (o Options) Run() error {
 		Run()
 
 	if err != nil {
-		allowErr := o.errIsValidTimeout(err)
-
-		if !allowErr {
+		if !o.errIsValidTimeout(err) {
 			return fmt.Errorf("unable to run confirm: %w", err)
 		}
 	}
@@ -48,7 +47,7 @@ func (o Options) Run() error {
 
 // errIsValidTimeout returns false unless 1) the user has specified a nonzero timeout and 2) the error is a huh.ErrTimeout.
 func (o Options) errIsValidTimeout(err error) bool {
-	errWasTimeout := err.Error() == huh.ErrTimeout.Error()
+	errWasTimeout := errors.Is(err, huh.ErrTimeout)
 	timeoutsExpected := o.Timeout > 0
 
 	return errWasTimeout && timeoutsExpected

--- a/confirm/command.go
+++ b/confirm/command.go
@@ -26,12 +26,17 @@ func (o Options) Run() error {
 				Value(&choice),
 		),
 	).
+		WithTimeout(o.Timeout).
 		WithTheme(theme).
 		WithShowHelp(o.ShowHelp).
 		Run()
 
 	if err != nil {
-		return fmt.Errorf("unable to run confirm: %w", err)
+		allowErr := o.errIsValidTimeout(err)
+
+		if !allowErr {
+			return fmt.Errorf("unable to run confirm: %w", err)
+		}
 	}
 
 	if !choice {
@@ -39,4 +44,12 @@ func (o Options) Run() error {
 	}
 
 	return nil
+}
+
+// errIsValidTimeout returns false unless 1) the user has specified a nonzero timeout and 2) the error is a huh.ErrTimeout.
+func (o Options) errIsValidTimeout(err error) bool {
+	errWasTimeout := err.Error() == huh.ErrTimeout.Error()
+	timeoutsExpected := o.Timeout > 0
+
+	return errWasTimeout && timeoutsExpected
 }

--- a/confirm/command_test.go
+++ b/confirm/command_test.go
@@ -1,0 +1,54 @@
+package confirm
+
+import (
+	"fmt"
+	"github.com/charmbracelet/huh"
+	"testing"
+	"time"
+)
+
+func TestOptions_errIsValidTimeout(t *testing.T) {
+	type testCase struct {
+		Description    string
+		GivenTimeout   time.Duration
+		GivenError     error
+		ExpectedResult bool
+	}
+
+	cases := []testCase{
+		{
+			Description:    "timeout is positive, err is a timeout",
+			GivenTimeout:   time.Second,
+			GivenError:     huh.ErrTimeout,
+			ExpectedResult: true,
+		},
+		{
+			Description:    "timeout is zero, err is a timeout",
+			GivenTimeout:   0,
+			GivenError:     huh.ErrTimeout,
+			ExpectedResult: false,
+		},
+		{
+			Description:    "timeout is positive, err is not a timeout",
+			GivenTimeout:   1,
+			GivenError:     fmt.Errorf("i'm not a timeout"),
+			ExpectedResult: false,
+		},
+		{
+			Description:    "timeout is zero, err is not a timeout",
+			GivenTimeout:   0,
+			GivenError:     fmt.Errorf("i'm not a timeout"),
+			ExpectedResult: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			sut := Options{Timeout: testCase.GivenTimeout}
+			actualResult := sut.errIsValidTimeout(testCase.GivenError)
+			if actualResult != testCase.ExpectedResult {
+				t.Errorf("got: %v, want: %v", actualResult, testCase.ExpectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #698.

Relevant excerpts from `gum confirm --help`

```console
Usage: gum confirm [<prompt>] [flags]

Ask a user to confirm an action

Arguments:
  [<prompt>]    Prompt to display.

Flags:
     --default              Default confirmation action
     --timeout=0            Timeout until confirm returns selected value or default if provided ($GUM_CONFIRM_TIMEOUT)
```

## Changes
- Chains a `.WithTimeout(o.Timeout)` in the `confirm` command's `huh.NewForm()` chain under `confirm.Run()`
- Adds an `errIsValidTimeout(error) bool` method to `confirm.Options` to facilitate safely ignoring the timeout error returned in the course of the `Run()` context expiring due to timeout
- Adds unit tests for `errIsValidTimeout`

## Demos

#### Before: doesn't time out without outside help

![Made with VHS](https://vhs.charm.sh/vhs-5uMkrm9SsjWRJlBj7YsPKq.gif)

Note that five seconds elapse here before `timeout` kills `gum`, returning a nonzero exit code.

```vhs
Set TypingSpeed 0.1
Output broken-main.gif
Set Shell zsh
Sleep 500ms
Type "git checkout main && git fetch upstream main && git rev-parse HEAD"
Enter
Type "date +%H:%M:%S.%1N && go run . confirm --timeout=1s --default='Yes' && echo 'Success'"
Enter
Sleep 4s
Ctrl+C
Type "date +%H:%M:%S.%1N"
Enter
Sleep 4s
Ctrl+D
```

#### After: times out as expected

![Made with VHS](https://vhs.charm.sh/vhs-5sBz2ESa8FjfjO8O65W7rS.gif)

Times out in ~1 second as desired.

```vhs
Output fixed.gif
Set Shell zsh
Sleep 500ms
Type "git checkout bug-confirm-timeout-was-missing && git rev-parse HEAD"
Enter
Sleep 1.5s
Type "go run . confirm --timeout=1s 'Am I going to time out?' --default='Yes' && echo Success"
Enter
Sleep 3s
Ctrl+D
```

Also works with `GUM_CONFIRM_TIMEOUT`.