### PR TITLE
docs(install): add x-cmd method to install gum

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ flox install gum
 # Windows (via WinGet or Scoop)
 winget install charmbracelet.gum
 scoop install charm-gum
+
+# X-CMD
+x env use gum
 ```
 
 <details>


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download gum release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the gum installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use gum
  # or
  x gum
  ```

- We wrote a [gum introduction article](https://www.x-cmd.com/pkg/gum)
