### PR TITLE
chore(nix): update src hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ pkgs.buildGoModule rec {
 
   src = ./.;
 
-  vendorHash = "sha256-gDDaKrwlrJyyDzgyGf9iP/XPnOAwpkvIyzCXobXrlF4=";
+  vendorHash = "sha256-UNBDVIz2VEizkhelCjadkzd2S2yTYXecTFUpCf+XtxY=";
 
   ldflags = [ "-s" "-w" "-X=main.Version=${version}" ];
 }


### PR DESCRIPTION
### Changes
- changed src hash to make main branch build through nix 

```
❯ nix develop
error: hash mismatch in fixed-output derivation '/nix/store/xcrnrbab9zgdzyq67xp2fr3cmws5g37s-gum-0.14.0-go-modules.drv':
         specified: sha256-gDDaKrwlrJyyDzgyGf9iP/XPnOAwpkvIyzCXobXrlF4=
            got:    sha256-UNBDVIz2VEizkhelCjadkzd2S2yTYXecTFUpCf+XtxY=
error: 1 dependencies of derivation '/nix/store/frz0ik8fcnsvkmn2kynlyxdfy4c8dk73-gum-0.14.0-env.drv' failed to build
```
