### PR TITLE
fix(filter): --no-strict not working, also weird behavior

### DIFF
--- a/filter/command.go
+++ b/filter/command.go
@@ -95,6 +95,7 @@ func (o Options) Run() error {
 		timeout:               o.Timeout,
 		hasTimeout:            o.Timeout > 0,
 		sort:                  o.Sort && o.FuzzySort,
+		strict:                o.Strict,
 	}, options...)
 
 	tm, err := p.Run()
@@ -121,9 +122,6 @@ func (o Options) Run() error {
 		}
 	}
 
-	if !o.Strict && len(m.textinput.Value()) != 0 && len(m.matches) == 0 {
-		fmt.Println(m.textinput.Value())
-	}
 	return nil
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -51,6 +51,7 @@ type model struct {
 	sort                  bool
 	timeout               time.Duration
 	hasTimeout            bool
+	strict                bool
 }
 
 func (m model) Init() tea.Cmd {
@@ -223,14 +224,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// A character was entered, this likely means that the text input has
 			// changed. This suggests that the matches are outdated, so update them.
+			var choices []string
+			if !m.strict {
+				choices = append(choices, m.textinput.Value())
+			}
+			choices = append(choices, m.choices...)
 			if m.fuzzy {
 				if m.sort {
-					m.matches = fuzzy.Find(m.textinput.Value(), m.choices)
+					m.matches = fuzzy.Find(m.textinput.Value(), choices)
 				} else {
-					m.matches = fuzzy.FindNoSort(m.textinput.Value(), m.choices)
+					m.matches = fuzzy.FindNoSort(m.textinput.Value(), choices)
 				}
 			} else {
-				m.matches = exactMatches(m.textinput.Value(), m.choices)
+				m.matches = exactMatches(m.textinput.Value(), choices)
 			}
 
 			// If the search field is empty, let's not display the matches

--- a/filter/options.go
+++ b/filter/options.go
@@ -15,7 +15,7 @@ type Options struct {
 	Limit                 int           `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit               bool          `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
 	SelectIfOne           bool          `help:"Select the given option if there is only one" group:"Selection"`
-	Strict                bool          `help:"Only returns if anything matched. Otherwise return Filter" negatable:"true" default:"true" group:"Selection"`
+	Strict                bool          `help:"Only returns if anything matched. Otherwise return Filter" negatable:"" default:"true" group:"Selection"`
 	SelectedPrefix        string        `help:"Character to indicate selected items (hidden if limit is 1)" default:" ◉ " env:"GUM_FILTER_SELECTED_PREFIX"`
 	SelectedPrefixStyle   style.Styles  `embed:"" prefix:"selected-indicator." set:"defaultForeground=212" envprefix:"GUM_FILTER_SELECTED_PREFIX_"`
 	UnselectedPrefix      string        `help:"Character to indicate unselected items (hidden if limit is 1)" default:" ○ " env:"GUM_FILTER_UNSELECTED_PREFIX"`


### PR DESCRIPTION
Fixes #695

### Changes
- `--no-strict` was erroring as non-existent option
- when `--no-strict`, we should actually create a "fake" option with whatever the user is typing