### PR TITLE
fix: strip ansi sequences from stdin

### DIFF
--- a/internal/stdin/stdin.go
+++ b/internal/stdin/stdin.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Read reads input from an stdin pipe.
@@ -28,7 +30,7 @@ func Read() (string, error) {
 		}
 	}
 
-	return strings.TrimSuffix(b.String(), "\n"), nil
+	return strings.TrimSuffix(ansi.Strip(b.String()), "\n"), nil
 }
 
 // IsEmpty returns whether stdin is empty.


### PR DESCRIPTION
most programs should not give output with ansi sequences to a pipe, but as some of them do, this will strip them out.

closes #188 