### PR TITLE
Quote tmux session name in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ $EDITOR $(gum filter)
 
 ```bash
 SESSION=$(tmux list-sessions -F \#S | gum filter --placeholder "Pick session...")
-tmux switch-client -t $SESSION || tmux attach -t $SESSION
+tmux switch-client -t "$SESSION" || tmux attach -t "$SESSION"
 ```
 
 - Pick a commit hash from `git` history


### PR DESCRIPTION
A tmux session name could contain a space. Quote the variable to avoid
the session name being split on spaces.

### Changes
- Update tmux session picker example in README to allow for session names which contain spaces
