### PR TITLE
fix(examples): remove -e from echo

### DIFF
--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -3,11 +3,11 @@
 gum style --border normal --margin "1" --padding "1 2" --border-foreground 212 "Hello, there! Welcome to $(gum style --foreground 212 'Gum')."
 NAME=$(gum input --placeholder "What is your name?")
 
-echo -e "Well, it is nice to meet you, $(gum style --foreground 212 "$NAME")."
+echo "Well, it is nice to meet you, $(gum style --foreground 212 "$NAME")."
 
 sleep 1; clear
 
-echo -e "Can you tell me a $(gum style --italic --foreground 99 'secret')?\n"
+echo "Can you tell me a $(gum style --italic --foreground 99 'secret')?\n"
 
 gum write --placeholder "I'll keep it to myself, I promise!" > /dev/null # we keep the secret to ourselves
 
@@ -24,7 +24,7 @@ grep -q "$DISCARD" <<< "$ACTIONS" && gum spin -s monkey --title " Discarding you
 
 sleep 1; clear
 
-GUM=$(echo -e "Cherry\nGrape\nLime\nOrange" | gum filter --placeholder "Favorite flavor?")
+GUM=$(echo "Cherry\nGrape\nLime\nOrange" | gum filter --placeholder "Favorite flavor?")
 echo "I'll keep that in mind!"
 
 sleep 1; clear


### PR DESCRIPTION
Fixes #751 

I don't think `-e` is needed since we use `gum style`? I don't encounter this issue anymore
![image](https://github.com/user-attachments/assets/f9bd5ff1-2ea0-47a1-b2cc-d7c5f8eb0b03)

