### PR TITLE
fix(pager): do not strip ansi sequences

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -27,7 +27,7 @@ func (o Options) Run() error {
 	)
 
 	if len(o.Options) <= 0 {
-		input, _ := stdin.Read()
+		input, _ := stdin.ReadStrip()
 		if input == "" {
 			return errors.New("no options provided, see `gum choose --help`")
 		}

--- a/filter/command.go
+++ b/filter/command.go
@@ -33,7 +33,7 @@ func (o Options) Run() error {
 	v := viewport.New(o.Width, o.Height)
 
 	if len(o.Options) == 0 {
-		if input, _ := stdin.Read(); input != "" {
+		if input, _ := stdin.ReadStrip(); input != "" {
 			o.Options = strings.Split(input, "\n")
 		} else {
 			o.Options = files.List()

--- a/format/command.go
+++ b/format/command.go
@@ -24,7 +24,7 @@ func (o Options) Run() error {
 	if len(o.Template) > 0 {
 		input = strings.Join(o.Template, "\n")
 	} else {
-		input, _ = stdin.Read()
+		input, _ = stdin.ReadStrip()
 	}
 
 	switch o.Type {

--- a/input/command.go
+++ b/input/command.go
@@ -16,7 +16,7 @@ import (
 // https://github.com/charmbracelet/bubbles/textinput
 func (o Options) Run() error {
 	if o.Value == "" {
-		if in, _ := stdin.Read(); in != "" {
+		if in, _ := stdin.ReadStrip(); in != "" {
 			o.Value = in
 		}
 	}
@@ -24,7 +24,7 @@ func (o Options) Run() error {
 	i := textinput.New()
 	if o.Value != "" {
 		i.SetValue(o.Value)
-	} else if in, _ := stdin.Read(); in != "" {
+	} else if in, _ := stdin.ReadStrip(); in != "" {
 		i.SetValue(in)
 	}
 	i.Focus()

--- a/internal/stdin/stdin.go
+++ b/internal/stdin/stdin.go
@@ -30,7 +30,13 @@ func Read() (string, error) {
 		}
 	}
 
-	return strings.TrimSuffix(ansi.Strip(b.String()), "\n"), nil
+	return strings.TrimSuffix(b.String(), "\n"), nil
+}
+
+// ReadStrip reads input from an stdin pipe and strips ansi sequences.
+func ReadStrip() (string, error) {
+	s, err := Read()
+	return ansi.Strip(s), err
 }
 
 // IsEmpty returns whether stdin is empty.

--- a/style/command.go
+++ b/style/command.go
@@ -20,7 +20,7 @@ func (o Options) Run() error {
 	if len(o.Text) > 0 {
 		text = strings.Join(o.Text, "\n")
 	} else {
-		text, _ = stdin.Read()
+		text, _ = stdin.ReadStrip()
 		if text == "" {
 			return errors.New("no input provided, see `gum style --help`")
 		}

--- a/write/command.go
+++ b/write/command.go
@@ -16,7 +16,7 @@ import (
 // Run provides a shell script interface for the text area bubble.
 // https://github.com/charmbracelet/bubbles/textarea
 func (o Options) Run() error {
-	in, _ := stdin.Read()
+	in, _ := stdin.ReadStrip()
 	if in != "" && o.Value == "" {
 		o.Value = strings.ReplaceAll(in, "\r", "")
 	}


### PR DESCRIPTION
it makes sense to strip everywhere else, but I think the pager is the exception.

closes #509
