### PR TITLE
fix(table): set widths

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -89,6 +89,14 @@ func (o Options) Run() error {
 		if len(row) > len(columns) {
 			return fmt.Errorf("invalid number of columns")
 		}
+		for i, col := range row {
+			if len(o.Widths) == 0 {
+				width := lipgloss.Width(col)
+				if width > columns[i].Width {
+					columns[i].Width = width
+				}
+			}
+		}
 		rows = append(rows, table.Row(row))
 	}
 


### PR DESCRIPTION
I'm not sure about this, as it might be slow in big tables...

This will go through all rows, calculate their widths, and set it as the column width if none was provided with `-w`.

```bash
# Without this patch:
echo -e "a,b\naaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb" | gum table
```

```
 a  b
 …  …
```

```bash
# With this patch:
echo -e "a,b\naaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb" | gum table
```

```
 a                        b
 aaaaaaaaaaaaaaaaaaaaaaa  bbbbbbbbbbbbbbbb
```

```bash
# In both:
echo -e "a,b\naaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbb" | gum table -w 5,5
```

```
 a      b
 aaaa…  bbbb…
```

closes #285
