### PR TITLE
fix(stdin): trim space instead of \n

### DIFF
--- a/internal/stdin/stdin.go
+++ b/internal/stdin/stdin.go
@@ -30,7 +30,7 @@ func Read() (string, error) {
 		}
 	}
 
-	return strings.TrimSuffix(b.String(), "\n"), nil
+	return strings.TrimSpace(b.String()), nil
 }
 
 // ReadStrip reads input from an stdin pipe and strips ansi sequences.


### PR DESCRIPTION
we were trimming an ending \n, but it would then break a \r\n sequence, causing misrenders.

this fixes it

closes #682
