### PR TITLE
feat(table): set --print if stdout is not a terminal

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/gum/style"
 	"github.com/charmbracelet/lipgloss"
 	ltable "github.com/charmbracelet/lipgloss/table"
+	"github.com/charmbracelet/x/term"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -102,7 +103,7 @@ func (o Options) Run() error {
 		rows = append(rows, table.Row(row))
 	}
 
-	if o.Print {
+	if o.Print || !term.IsTerminal(os.Stdout.Fd()) {
 		table := ltable.New().
 			Headers(columnNames...).
 			Rows(data...).


### PR DESCRIPTION
this makes it automatically set `--print` if stdout is not a terminal, e.g., when piping into something else. 

Seems to me that this is what you would want anyway!