### PR TITLE
fix(spin): if not a tty, only print title, do not open tty for stdin

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -26,16 +26,22 @@ func (o Options) Run() error {
 		align:      o.Align,
 		showOutput: o.ShowOutput && isTTY,
 		showError:  o.ShowError,
+		isTTY:      isTTY,
 	}
 
 	ctx, cancel := timeout.Context(o.Timeout)
 	defer cancel()
 
-	tm, err := tea.NewProgram(
-		m,
+	opts := []tea.ProgramOption{
 		tea.WithOutput(os.Stderr),
 		tea.WithContext(ctx),
-	).Run()
+	}
+
+	if !isTTY {
+		opts = append(opts, tea.WithInput(nil))
+	}
+
+	tm, err := tea.NewProgram(m, opts...).Run()
 	if err != nil {
 		return fmt.Errorf("unable to run action: %w", err)
 	}

--- a/spin/spin.go
+++ b/spin/spin.go
@@ -32,6 +32,7 @@ type model struct {
 	align      string
 	command    []string
 	quitting   bool
+	isTTY      bool
 	status     int
 	stdout     string
 	stderr     string
@@ -101,6 +102,10 @@ func (m model) Init() tea.Cmd {
 }
 
 func (m model) View() string {
+	if !m.isTTY {
+		return m.title
+	}
+
 	if m.quitting && m.showOutput {
 		return strings.TrimPrefix(errbuf.String()+"\n"+outbuf.String(), "\n")
 	}


### PR DESCRIPTION
bubbletea by default will try to open a tty for stdin, this makes it not do that if we're not on a terminal (e.g. docker build)

on the same token, simplify rendering in that case, printing only the title ("Loading..." by default).

closes #328
