### PR TITLE
feat: esc exit 1, ctrl+c exit 130, help arrow order

### DIFF
--- a/choose/choose.go
+++ b/choose/choose.go
@@ -24,23 +24,18 @@ func defaultKeymap() keymap {
 	return keymap{
 		Down: key.NewBinding(
 			key.WithKeys("down", "j", "ctrl+j", "ctrl+n"),
-			key.WithHelp("↓", "down"),
 		),
 		Up: key.NewBinding(
 			key.WithKeys("up", "k", "ctrl+k", "ctrl+p"),
-			key.WithHelp("↑", "up"),
 		),
 		Right: key.NewBinding(
 			key.WithKeys("right", "l", "ctrl+f"),
-			key.WithHelp("→", "right"),
 		),
 		Left: key.NewBinding(
 			key.WithKeys("left", "h", "ctrl+b"),
-			key.WithHelp("←", "left"),
 		),
 		Home: key.NewBinding(
 			key.WithKeys("g", "home"),
-			key.WithHelp("g", "home"),
 		),
 		End: key.NewBinding(
 			key.WithKeys("G", "end"),
@@ -57,8 +52,12 @@ func defaultKeymap() keymap {
 			key.WithDisabled(),
 		),
 		Abort: key.NewBinding(
-			key.WithKeys("ctrl+c", "esc"),
+			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "abort"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "quit"),
 		),
 		Submit: key.NewBinding(
 			key.WithKeys("enter", "ctrl+q"),
@@ -77,6 +76,7 @@ type keymap struct {
 	ToggleAll,
 	Toggle,
 	Abort,
+	Quit,
 	Submit key.Binding
 }
 
@@ -89,7 +89,7 @@ func (k keymap) ShortHelp() []key.Binding {
 		k.Toggle,
 		key.NewBinding(
 			key.WithKeys("up", "down", "right", "left"),
-			key.WithHelp("↑↓←→", "navigate"),
+			key.WithHelp("←↓↑→", "navigate"),
 		),
 		k.Submit,
 		k.ToggleAll,
@@ -105,6 +105,7 @@ type model struct {
 	header           string
 	items            []item
 	quitting         bool
+	submitted        bool
 	index            int
 	limit            int
 	numSelected      int
@@ -177,6 +178,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m = m.deselectAll()
 			}
+		case key.Matches(msg, km.Quit):
+			m.quitting = true
+			return m, tea.Quit
 		case key.Matches(msg, km.Abort):
 			m.quitting = true
 			return m, tea.Interrupt
@@ -199,6 +203,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.limit <= 1 && m.numSelected < 1 {
 				m.items[m.index].selected = true
 			}
+			m.submitted = true
 			return m, tea.Quit
 		}
 	}

--- a/choose/command.go
+++ b/choose/command.go
@@ -136,6 +136,9 @@ func (o Options) Run() error {
 		return fmt.Errorf("unable to pick selection: %w", err)
 	}
 	m = tm.(model)
+	if !m.submitted {
+		return errors.New("nothing selected")
+	}
 	if o.Ordered && o.Limit > 1 {
 		sort.Slice(m.items, func(i, j int) bool {
 			return m.items[i].order < m.items[j].order

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -47,7 +47,7 @@ func defaultKeymap(affirmative, negative string) keymap {
 				"ctrl+p",
 				"tab",
 			),
-			key.WithHelp("←/→", "toggle"),
+			key.WithHelp("←→", "toggle"),
 		),
 		Submit: key.NewBinding(
 			key.WithKeys("enter"),

--- a/file/file.go
+++ b/file/file.go
@@ -34,8 +34,6 @@ var keyAbort = key.NewBinding(
 
 func defaultKeymap() keymap {
 	km := filepicker.DefaultKeyMap()
-	km.Down.SetHelp("↓", "down")
-	km.Up.SetHelp("↑", "up")
 	return keymap(km)
 }
 
@@ -45,8 +43,10 @@ func (k keymap) FullHelp() [][]key.Binding { return nil }
 // ShortHelp implements help.KeyMap.
 func (k keymap) ShortHelp() []key.Binding {
 	return []key.Binding{
-		k.Up,
-		k.Down,
+		key.NewBinding(
+			key.WithKeys("up", "down"),
+			key.WithHelp("↓↑", "navigate"),
+		),
 		keyQuit,
 		k.Select,
 	}

--- a/filter/command.go
+++ b/filter/command.go
@@ -119,6 +119,9 @@ func (o Options) Run() error {
 	}
 
 	m := tm.(model)
+	if !m.submitted {
+		return errors.New("nothing selected")
+	}
 	isTTY := term.IsTerminal(os.Stdout.Fd())
 
 	// allSelections contains values only if limit is greater

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -26,11 +26,9 @@ func defaultKeymap() keymap {
 	return keymap{
 		Down: key.NewBinding(
 			key.WithKeys("down", "ctrl+j", "ctrl+n"),
-			key.WithHelp("↓", "down"),
 		),
 		Up: key.NewBinding(
 			key.WithKeys("up", "ctrl+k", "ctrl+p"),
-			key.WithHelp("↑", "up"),
 		),
 		ToggleAndNext: key.NewBinding(
 			key.WithKeys("tab"),
@@ -47,8 +45,12 @@ func defaultKeymap() keymap {
 			key.WithHelp("ctrl+@", "toggle"),
 			key.WithDisabled(),
 		),
+		Quit: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "quit"),
+		),
 		Abort: key.NewBinding(
-			key.WithKeys("ctrl+c", "esc"),
+			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "abort"),
 		),
 		Submit: key.NewBinding(
@@ -65,6 +67,7 @@ type keymap struct {
 	ToggleAndPrevious,
 	Toggle,
 	Abort,
+	Quit,
 	Submit key.Binding
 }
 
@@ -77,7 +80,7 @@ func (k keymap) ShortHelp() []key.Binding {
 		k.ToggleAndNext,
 		key.NewBinding(
 			key.WithKeys("up", "down"),
-			key.WithHelp("↑↓", "navigate"),
+			key.WithHelp("↓↑", "navigate"),
 		),
 		k.Submit,
 	}
@@ -112,6 +115,7 @@ type model struct {
 	keymap                keymap
 	help                  help.Model
 	strict                bool
+	submitted             bool
 }
 
 func (m model) Init() tea.Cmd { return textinput.Blink }
@@ -251,11 +255,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		km := m.keymap
 		switch {
+		case key.Matches(msg, km.Quit):
+			m.quitting = true
+			return m, tea.Quit
 		case key.Matches(msg, km.Abort):
 			m.quitting = true
 			return m, tea.Interrupt
 		case key.Matches(msg, km.Submit):
 			m.quitting = true
+			m.submitted = true
 			return m, tea.Quit
 		case key.Matches(msg, km.Down):
 			m.CursorDown()

--- a/gum.go
+++ b/gum.go
@@ -133,7 +133,7 @@ type Gum struct {
 	// │    7 │                                         │
 	// │    8 │                                         │
 	// ╰────────────────────────────────────────────────╯
-	//  ↑/↓: Navigate • q: Quit
+	//  ↓↑: navigate • q: quit
 	//
 	Pager pager.Options `cmd:"" help:"Scroll through a file"`
 

--- a/input/command.go
+++ b/input/command.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -67,6 +68,9 @@ func (o Options) Run() error {
 	}
 
 	m = tm.(model)
+	if !m.submitted {
+		return errors.New("not submitted")
+	}
 	fmt.Println(m.textinput.Value())
 	return nil
 }

--- a/input/input.go
+++ b/input/input.go
@@ -41,6 +41,7 @@ type model struct {
 	headerStyle lipgloss.Style
 	textinput   textinput.Model
 	quitting    bool
+	submitted   bool
 	showHelp    bool
 	help        help.Model
 	keymap      keymap
@@ -79,8 +80,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c":
 			m.quitting = true
 			return m, tea.Interrupt
-		case "esc", "enter":
+		case "esc":
 			m.quitting = true
+			return m, tea.Quit
+		case "enter":
+			m.quitting = true
+			m.submitted = true
 			return m, tea.Quit
 		}
 	}

--- a/pager/pager.go
+++ b/pager/pager.go
@@ -38,7 +38,7 @@ func (k keymap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(
 			key.WithKeys("up", "down"),
-			key.WithHelp("↑/↓", "navigate"),
+			key.WithHelp("↓↑", "navigate"),
 		),
 		k.Quit,
 		k.Search,

--- a/table/table.go
+++ b/table/table.go
@@ -44,7 +44,7 @@ func defaultKeymap() keymap {
 	return keymap{
 		Navigate: key.NewBinding(
 			key.WithKeys("up", "down"),
-			key.WithHelp("↑↓", "navigate"),
+			key.WithHelp("↓↑", "navigate"),
 		),
 		Select: key.NewBinding(
 			key.WithKeys("enter"),

--- a/write/command.go
+++ b/write/command.go
@@ -1,6 +1,7 @@
 package write
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -73,6 +74,9 @@ func (o Options) Run() error {
 		return fmt.Errorf("failed to run write: %w", err)
 	}
 	m = tm.(model)
+	if !m.submitted {
+		return errors.New("not submitted")
+	}
 	fmt.Println(m.textarea.Value())
 	return nil
 }

--- a/write/write.go
+++ b/write/write.go
@@ -23,6 +23,7 @@ import (
 type keymap struct {
 	textarea.KeyMap
 	Submit       key.Binding
+	Quit         key.Binding
 	Abort        key.Binding
 	OpenInEditor key.Binding
 }
@@ -47,6 +48,10 @@ func defaultKeymap() keymap {
 	)
 	return keymap{
 		KeyMap: km,
+		Quit: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "quit"),
+		),
 		Abort: key.NewBinding(
 			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "cancel"),
@@ -67,6 +72,7 @@ type model struct {
 	header      string
 	headerStyle lipgloss.Style
 	quitting    bool
+	submitted   bool
 	textarea    textarea.Model
 	showHelp    bool
 	help        help.Model
@@ -117,8 +123,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, km.Abort):
 			m.quitting = true
 			return m, tea.Interrupt
+		case key.Matches(msg, km.Quit):
+			m.quitting = true
+			return m, tea.Quit
 		case key.Matches(msg, km.Submit):
 			m.quitting = true
+			m.submitted = true
 			return m, tea.Quit
 		case key.Matches(msg, km.OpenInEditor):
 			//nolint: gosec


### PR DESCRIPTION
Some standards:

- Esc exits 1
- CTRL+C exits 130 (interrupt)
- Help arrows are always in HJKL order

closes #138