### PR TITLE
feat(filter): --select-if-one returns if single match

### DIFF
--- a/internal/tty/tty.go
+++ b/internal/tty/tty.go
@@ -1,0 +1,24 @@
+// Package tty provides tty-aware printing.
+package tty
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/term"
+)
+
+var isTTY = sync.OnceValue(func() bool {
+	return term.IsTerminal(os.Stdout.Fd())
+})
+
+// Println handles println, striping ansi sequences if stdout is not a tty.
+func Println(s string) {
+	if isTTY() {
+		fmt.Println(s)
+		return
+	}
+	fmt.Println(ansi.Strip(s))
+}


### PR DESCRIPTION
- currently, `--select-if-one` returns directly only if there is one option
- this pr changes it so it also returns if a `--value` is provided, and matching only gives 1 option, which is likely the expected behavior of that flag
- also made an internal tty package to handle printing results better


closes #311
