### PR TITLE
feat(choose,filter): --input-delimiter --output-delimiter

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -13,9 +13,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/gum/internal/stdin"
 	"github.com/charmbracelet/gum/internal/timeout"
+	"github.com/charmbracelet/gum/internal/tty"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/ansi"
-	"github.com/charmbracelet/x/term"
 )
 
 // Run provides a shell script interface for choosing between different through
@@ -153,12 +152,6 @@ func (o Options) Run() error {
 			out = append(out, item.text)
 		}
 	}
-
-	if term.IsTerminal(os.Stdout.Fd()) {
-		fmt.Println(strings.Join(out, o.OutputDelimiter))
-	} else {
-		fmt.Println(ansi.Strip(strings.Join(out, o.OutputDelimiter)))
-	}
-
+	tty.Println(strings.Join(out, o.OutputDelimiter))
 	return nil
 }

--- a/choose/command.go
+++ b/choose/command.go
@@ -31,7 +31,7 @@ func (o Options) Run() error {
 		if input == "" {
 			return errors.New("no options provided, see `gum choose --help`")
 		}
-		o.Options = strings.Split(input, "\n")
+		o.Options = strings.Split(input, o.InputDelimiter)
 	}
 
 	if o.SelectIfOne && len(o.Options) == 1 {
@@ -146,18 +146,18 @@ func (o Options) Run() error {
 			return m.items[i].order < m.items[j].order
 		})
 	}
-	var s strings.Builder
+
+	var out []string
 	for _, item := range m.items {
 		if item.selected {
-			s.WriteString(item.text)
-			s.WriteRune('\n')
+			out = append(out, item.text)
 		}
 	}
 
 	if term.IsTerminal(os.Stdout.Fd()) {
-		fmt.Print(s.String())
+		fmt.Println(strings.Join(out, o.OutputDelimiter))
 	} else {
-		fmt.Print(ansi.Strip(s.String()))
+		fmt.Println(ansi.Strip(strings.Join(out, o.OutputDelimiter)))
 	}
 
 	return nil

--- a/choose/options.go
+++ b/choose/options.go
@@ -22,6 +22,8 @@ type Options struct {
 	UnselectedPrefix string        `help:"Prefix to show on unselected items (hidden if limit is 1)" default:"• " env:"GUM_CHOOSE_UNSELECTED_PREFIX"`
 	Selected         []string      `help:"Options that should start as selected (selects all if given '*')" default:"" env:"GUM_CHOOSE_SELECTED"`
 	SelectIfOne      bool          `help:"Select the given option if there is only one" group:"Selection"`
+	InputDelimiter   string        `help:"Option delimiter when reading from STDIN" default:"\n" env:"GUM_CHOOSE_INPUT_DELIMITER"`
+	OutputDelimiter  string        `help:"Option delimiter when writing to STDOUT" default:"\n" env:"GUM_CHOOSE_OUTPUT_DELIMITER"`
 
 	CursorStyle       style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_CURSOR_"`
 	HeaderStyle       style.Styles `embed:"" prefix:"header." set:"defaultForeground=99" envprefix:"GUM_CHOOSE_HEADER_"`

--- a/filter/command.go
+++ b/filter/command.go
@@ -34,7 +34,7 @@ func (o Options) Run() error {
 
 	if len(o.Options) == 0 {
 		if input, _ := stdin.ReadStrip(); input != "" {
-			o.Options = strings.Split(input, "\n")
+			o.Options = strings.Split(input, o.InputDelimiter)
 		} else {
 			o.Options = files.List()
 		}
@@ -142,11 +142,12 @@ func (o Options) Run() error {
 }
 
 func (o Options) checkSelected(m model, isTTY bool) {
+	out := []string{}
 	for k := range m.selected {
 		if isTTY {
-			fmt.Println(k)
-		} else {
-			fmt.Println(ansi.Strip(k))
+			k = ansi.Strip(k)
 		}
+		out = append(out, k)
 	}
+	fmt.Println(strings.Join(out, o.OutputDelimiter))
 }

--- a/filter/options.go
+++ b/filter/options.go
@@ -37,6 +37,8 @@ type Options struct {
 	Fuzzy                 bool          `help:"Enable fuzzy matching; otherwise match from start of word" default:"true" env:"GUM_FILTER_FUZZY" negatable:""`
 	FuzzySort             bool          `help:"Sort fuzzy results by their scores" default:"true" env:"GUM_FILTER_FUZZY_SORT" negatable:""`
 	Timeout               time.Duration `help:"Timeout until filter command aborts" default:"0s" env:"GUM_FILTER_TIMEOUT"`
+	InputDelimiter        string        `help:"Option delimiter when reading from STDIN" default:"\n" env:"GUM_FILTER_INPUT_DELIMITER"`
+	OutputDelimiter       string        `help:"Option delimiter when writing to STDOUT" default:"\n" env:"GUM_FILTER_OUTPUT_DELIMITER"`
 
 	// Deprecated: use [FuzzySort]. This will be removed at some point.
 	Sort bool `help:"Sort fuzzy results by their scores" default:"true" env:"GUM_FILTER_FUZZY_SORT" negatable:"" hidden:""`


### PR DESCRIPTION
allows to change how content from stdin is used, and how results are printed.

one could get around it piping into and from `tr`, but results aren't quite right, especially when `tr '\n' ','` for example, as it'll add an extra `,` in the end of the string.

This makes things a bit cleaner, hopefully.

closes #274
