### PR TITLE
feat: add --[no-]strip-ansi-codes option

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -26,7 +26,7 @@ func (o Options) Run() error {
 	)
 
 	if len(o.Options) <= 0 {
-		input, _ := stdin.ReadStrip()
+		input, _ := stdin.ReadWithOptions(&o)
 		if input == "" {
 			return errors.New("no options provided, see `gum choose --help`")
 		}

--- a/choose/options.go
+++ b/choose/options.go
@@ -29,4 +29,10 @@ type Options struct {
 	HeaderStyle       style.Styles `embed:"" prefix:"header." set:"defaultForeground=99" envprefix:"GUM_CHOOSE_HEADER_"`
 	ItemStyle         style.Styles `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`
 	SelectedItemStyle style.Styles `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_"`
+
+	StripANSICodes bool `help:"Strip ANSI codes from the input" negatable:"" default:"true" env:"GUM_CHOOSE_STRIP_ANSI_CODES"`
+}
+
+func (o *Options) DoStripANSICodes() bool {
+	return o.StripANSICodes
 }

--- a/filter/command.go
+++ b/filter/command.go
@@ -32,7 +32,7 @@ func (o Options) Run() error {
 	v := viewport.New(o.Width, o.Height)
 
 	if len(o.Options) == 0 {
-		if input, _ := stdin.ReadStrip(); input != "" {
+		if input, _ := stdin.ReadWithOptions(&o); input != "" {
 			o.Options = strings.Split(input, o.InputDelimiter)
 		} else {
 			o.Options = files.List()

--- a/filter/options.go
+++ b/filter/options.go
@@ -43,4 +43,10 @@ type Options struct {
 
 	// Deprecated: use [FuzzySort]. This will be removed at some point.
 	Sort bool `help:"Sort fuzzy results by their scores" default:"true" env:"GUM_FILTER_FUZZY_SORT" negatable:"" hidden:""`
+
+	StripANSICodes bool `help:"Strip ANSI codes from the input" negatable:"" default:"true" env:"GUM_FILTER_STRIP_ANSI_CODES"`
+}
+
+func (o *Options) DoStripANSICodes() bool {
+	return o.StripANSICodes
 }

--- a/format/command.go
+++ b/format/command.go
@@ -24,7 +24,7 @@ func (o Options) Run() error {
 	if len(o.Template) > 0 {
 		input = strings.Join(o.Template, "\n")
 	} else {
-		input, _ = stdin.ReadStrip()
+		input, _ = stdin.ReadWithOptions(&o)
 	}
 
 	switch o.Type {

--- a/format/options.go
+++ b/format/options.go
@@ -7,4 +7,10 @@ type Options struct {
 	Language string   `help:"Programming language to parse code" short:"l" default:"" env:"GUM_FORMAT_LANGUAGE"`
 
 	Type string `help:"Format to use (markdown,template,code,emoji)" enum:"markdown,template,code,emoji" short:"t" default:"markdown" env:"GUM_FORMAT_TYPE"`
+
+	StripANSICodes bool `help:"Strip ANSI codes from the input" negatable:"" default:"true" env:"GUM_FORMAT_STRIP_ANSI_CODES"`
+}
+
+func (o *Options) DoStripANSICodes() bool {
+	return o.StripANSICodes
 }

--- a/input/command.go
+++ b/input/command.go
@@ -17,7 +17,7 @@ import (
 // https://github.com/charmbracelet/bubbles/textinput
 func (o Options) Run() error {
 	if o.Value == "" {
-		if in, _ := stdin.ReadStrip(); in != "" {
+		if in, _ := stdin.ReadWithOptions(&o); in != "" {
 			o.Value = in
 		}
 	}
@@ -25,7 +25,7 @@ func (o Options) Run() error {
 	i := textinput.New()
 	if o.Value != "" {
 		i.SetValue(o.Value)
-	} else if in, _ := stdin.ReadStrip(); in != "" {
+	} else if in, _ := stdin.ReadWithOptions(&o); in != "" {
 		i.SetValue(in)
 	}
 	i.Focus()

--- a/input/options.go
+++ b/input/options.go
@@ -22,4 +22,10 @@ type Options struct {
 	Header           string        `help:"Header value" default:"" env:"GUM_INPUT_HEADER"`
 	HeaderStyle      style.Styles  `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_INPUT_HEADER_"`
 	Timeout          time.Duration `help:"Timeout until input aborts" default:"0s" env:"GUM_INPUT_TIMEOUT"`
+
+	StripANSICodes bool `help:"Strip ANSI codes from the input" negatable:"" default:"true" env:"GUM_INPUT_STRIP_ANSI_CODES"`
+}
+
+func (o *Options) DoStripANSICodes() bool {
+	return o.StripANSICodes
 }

--- a/internal/stdin/options.go
+++ b/internal/stdin/options.go
@@ -1,0 +1,19 @@
+package stdin
+
+// StdinOptions provide switches for ReadWithOptions, indicating how to read
+// input from stdin
+type StdinOptions interface {
+	// DoStripANSICodes returns true if the ANSI codes should be stripped from the
+	// input.
+	DoStripANSICodes() bool
+}
+
+// ReadWithOptions delegates to the module's Read functions based on the
+// provided options instance.
+func ReadWithOptions(opts StdinOptions) (string, error) {
+	if opts.DoStripANSICodes() {
+		return ReadStrip()
+	} else {
+		return Read()
+	}
+}

--- a/style/command.go
+++ b/style/command.go
@@ -20,7 +20,7 @@ func (o Options) Run() error {
 	if len(o.Text) > 0 {
 		text = strings.Join(o.Text, "\n")
 	} else {
-		text, _ = stdin.ReadStrip()
+		text, _ = stdin.ReadWithOptions(&o)
 		if text == "" {
 			return errors.New("no input provided, see `gum style --help`")
 		}

--- a/style/options.go
+++ b/style/options.go
@@ -5,6 +5,12 @@ type Options struct {
 	Text  []string        `arg:"" optional:"" help:"Text to which to apply the style"`
 	Trim  bool            `help:"Trim whitespaces on every input line" default:"false"`
 	Style StylesNotHidden `embed:""`
+
+	StripANSICodes bool `help:"Strip ANSI codes from the input" negatable:"" default:"true" env:"GUM_STYLE_STRIP_ANSI_CODES"`
+}
+
+func (o *Options) DoStripANSICodes() bool {
+	return o.StripANSICodes
 }
 
 // Styles is a flag set of possible styles.

--- a/write/command.go
+++ b/write/command.go
@@ -17,7 +17,7 @@ import (
 // Run provides a shell script interface for the text area bubble.
 // https://github.com/charmbracelet/bubbles/textarea
 func (o Options) Run() error {
-	in, _ := stdin.ReadStrip()
+	in, _ := stdin.ReadWithOptions(&o)
 	if in != "" && o.Value == "" {
 		o.Value = strings.ReplaceAll(in, "\r", "")
 	}

--- a/write/options.go
+++ b/write/options.go
@@ -31,4 +31,10 @@ type Options struct {
 	HeaderStyle           style.Styles `embed:"" prefix:"header." set:"defaultForeground=240" envprefix:"GUM_WRITE_HEADER_"`
 	PlaceholderStyle      style.Styles `embed:"" prefix:"placeholder." set:"defaultForeground=240" envprefix:"GUM_WRITE_PLACEHOLDER_"`
 	PromptStyle           style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=7" envprefix:"GUM_WRITE_PROMPT_"`
+
+	StripANSICodes bool `help:"Strip ANSI codes from the input" negatable:"" default:"true" env:"GUM_WRITE_STRIP_ANSI_CODES"`
+}
+
+func (o *Options) DoStripANSICodes() bool {
+	return o.StripANSICodes
 }


### PR DESCRIPTION
refs: #739, https://github.com/charmbracelet/gum/issues/188#issuecomment-1272654231

I chose to hide the conditional behind an interface to simplify the call sites and duplication of flag processing across commands. If we add further stdin-related options in the future, this would become more useful, as more logic would be abstracted away. However, I can see the argument against this approach; this pattern isn't used in the rest of the codebase (from what I saw), and adding it for such a small feature might not be worth the added complexity. In that case, it would be pretty easy to get rid of the interface and just inline the conditional in every command.