### PR TITLE
fix(filter): properly handle options with ansi styles

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -219,7 +219,7 @@ func (m model) View() string {
 			// fmt.Print("here ", lastIdx, rng, " - ", match.Str[rng[0]:rng[1]+1], "\r\n")
 			// Add the text before this match
 			if rng[0] > lastIdx {
-				buf.WriteString(ansiCut(styledOption, rng[0], lastIdx))
+				buf.WriteString(ansiCut(styledOption, lastIdx, rng[0]))
 			}
 
 			// Add the matched character with highlight
@@ -524,10 +524,10 @@ func clamp(low, high, val int) int {
 }
 
 func ansiCut(s string, left, right int) string {
-	if right == 0 {
-		return ansi.Truncate(s, left, "")
+	if left == 0 {
+		return ansi.Truncate(s, right, "")
 	}
-	return ansi.TruncateLeft(ansi.Truncate(s, left, ""), right, "")
+	return ansi.TruncateLeft(ansi.Truncate(s, right, ""), left, "")
 }
 
 func matchedRanges(in []int) [][2]int {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -219,7 +219,7 @@ func (m model) View() string {
 			// fmt.Print("here ", lastIdx, rng, " - ", match.Str[rng[0]:rng[1]+1], "\r\n")
 			// Add the text before this match
 			if rng[0] > lastIdx {
-				buf.WriteString(ansiCut(styledOption, lastIdx, rng[0]))
+				buf.WriteString(ansi.Cut(styledOption, lastIdx, rng[0]))
 			}
 
 			// Add the matched character with highlight
@@ -521,13 +521,6 @@ func clamp(low, high, val int) int {
 		return high
 	}
 	return val
-}
-
-func ansiCut(s string, left, right int) string {
-	if left == 0 {
-		return ansi.Truncate(s, right, "")
-	}
-	return ansi.TruncateLeft(ansi.Truncate(s, right, ""), left, "")
 }
 
 func matchedRanges(in []int) [][2]int {

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1,0 +1,41 @@
+package filter
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMatchedRanges(t *testing.T) {
+	for name, tt := range map[string]struct {
+		in  []int
+		out [][2]int
+	}{
+		"empty": {
+			in:  []int{},
+			out: [][2]int{},
+		},
+		"one char": {
+			in:  []int{1},
+			out: [][2]int{{1, 1}},
+		},
+		"2 char range": {
+			in:  []int{1, 2},
+			out: [][2]int{{1, 2}},
+		},
+		"multiple char range": {
+			in:  []int{1, 2, 3, 4, 5, 6},
+			out: [][2]int{{1, 6}},
+		},
+		"multiple char ranges": {
+			in:  []int{1, 2, 3, 5, 6, 10, 11, 12, 13, 23, 24, 40, 42, 43, 45, 52},
+			out: [][2]int{{1, 3}, {5, 6}, {10, 13}, {23, 24}, {40, 40}, {42, 43}, {45, 45}, {52, 52}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			match := matchedRanges(tt.in)
+			if !reflect.DeepEqual(match, tt.out) {
+				t.Errorf("expected %v, got %v", tt.out, match)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/charmbracelet/log v0.4.0
-	github.com/charmbracelet/x/ansi v0.6.0
+	github.com/charmbracelet/x/ansi v0.6.1-0.20250107110353-48b574af22a5
 	github.com/charmbracelet/x/editor v0.1.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O
 github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
 github.com/charmbracelet/log v0.4.0 h1:G9bQAcx8rWA2T3pWvx7YtPTPwgqpk7D68BX21IRW8ZM=
 github.com/charmbracelet/log v0.4.0/go.mod h1:63bXt/djrizTec0l11H20t8FDSvA4CRZJ1KH22MdptM=
-github.com/charmbracelet/x/ansi v0.6.0 h1:qOznutrb93gx9oMiGf7caF7bqqubh6YIM0SWKyA08pA=
-github.com/charmbracelet/x/ansi v0.6.0/go.mod h1:KBUFw1la39nl0dLl10l5ORDAqGXaeurTQmwyyVKse/Q=
+github.com/charmbracelet/x/ansi v0.6.1-0.20250107110353-48b574af22a5 h1:TSjbA80sXnABV/Vxhnb67Ho7p8bEYqz6NIdhLAx+1yg=
+github.com/charmbracelet/x/ansi v0.6.1-0.20250107110353-48b574af22a5/go.mod h1:KBUFw1la39nl0dLl10l5ORDAqGXaeurTQmwyyVKse/Q=
 github.com/charmbracelet/x/editor v0.1.0 h1:p69/dpvlwRTs9uYiPeAWruwsHqTFzHhTvQOd/WVSX98=
 github.com/charmbracelet/x/editor v0.1.0/go.mod h1:oivrEbcP/AYt/Hpvk5pwDXXrQ933gQS6UzL6fxqAGSA=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b h1:MnAMdlwSltxJyULnrYbkZpp4k58Co7Tah3ciKhSNo0Q=


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/gum/issues/785

- it will fuzzy match against the stripped string 
- it will then render the styles string, taking ansi escape codes into account
- when a char matches, it'll use the matched style instead of whatever style the item had previously
- other chars will have their previous style though
- refactored the matches styling to do it in ranges instead of per char basis, as we now need to `ansi.Truncate`/`ansi.TruncateLeft` to avoid breaking styles

some screenshots:

![CleanShot 2025-01-06 at 17 17 09@2x](https://github.com/user-attachments/assets/be35c8d7-eb20-4278-a74d-dbe435d005cf)
![CleanShot 2025-01-06 at 17 17 30@2x](https://github.com/user-attachments/assets/8c3f8f72-0d1b-4be9-9562-828b6d1887b2)
![CleanShot 2025-01-06 at 17 17 38@2x](https://github.com/user-attachments/assets/f30289e5-b338-4d35-ae4a-6dbad42150b7)
![CleanShot 2025-01-06 at 17 17 42@2x](https://github.com/user-attachments/assets/b10a3bc5-56b0-4365-aff7-71dd8514c099)

