### PR TITLE
feat/pager: implement markdown syntax highlighting (#804)

### DIFF
--- a/pager/command.go
+++ b/pager/command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/gum/internal/stdin"
 	"github.com/charmbracelet/gum/internal/timeout"
 )
@@ -28,6 +29,19 @@ func (o Options) Run() error {
 			o.Content = backspace.ReplaceAllString(stdin, "")
 		} else {
 			return fmt.Errorf("provide some content to display")
+		}
+	}
+
+	if o.SyntaxHighlight != "" {
+		switch {
+		case o.SyntaxHighlight == "markdown":
+			renderedContent, err := glamour.Render(o.Content, "dark")
+			if err != nil {
+				return fmt.Errorf("unable to render: %w", err)
+			}
+			o.Content = renderedContent
+		default:
+			return fmt.Errorf("syntax-highlight language: markdown")
 		}
 	}
 

--- a/pager/options.go
+++ b/pager/options.go
@@ -10,6 +10,7 @@ import (
 type Options struct {
 	//nolint:staticcheck
 	Style               style.Styles  `embed:"" help:"Style the pager" set:"defaultBorder=rounded" set:"defaultPadding=0 1" set:"defaultBorderForeground=212" envprefix:"GUM_PAGER_"`
+	SyntaxHighlight     string        `help:"syntax highlighting (support language: markdown)" default:""`
 	Content             string        `arg:"" optional:"" help:"Display content to scroll"`
 	ShowLineNumbers     bool          `help:"Show line numbers" default:"true"`
 	LineNumberStyle     style.Styles  `embed:"" prefix:"line-number." help:"Style the line numbers" set:"defaultForeground=237" envprefix:"GUM_PAGER_LINE_NUMBER_"`


### PR DESCRIPTION
Implementation of #804 

### Changes
- `cli:pager`: new flag `--syntax-highlight=<language>` to support syntax highlighting. Current support: `markdown`.

### Demo
![demo](https://github.com/user-attachments/assets/783bb81a-a059-43ac-b390-d687996901c0)