### PR TITLE
feat(table): Add interactive flag for #800

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -110,7 +110,7 @@ func (o Options) Run() error {
 		rows = append(rows, table.Row(data[row]))
 	}
 
-	if !o.Interactive && (o.Print || !term.IsTerminal(os.Stdout.Fd())) {
+	if !o.Interactive && (o.Print || !term.IsTerminal(os.Stdin.Fd())) {
 		table := ltable.New().
 			Headers(columnNames...).
 			Rows(data...).

--- a/table/command.go
+++ b/table/command.go
@@ -110,7 +110,7 @@ func (o Options) Run() error {
 		rows = append(rows, table.Row(data[row]))
 	}
 
-	if o.Print || !term.IsTerminal(os.Stdout.Fd()) {
+	if !o.Interactive && (o.Print || !term.IsTerminal(os.Stdout.Fd())) {
 		table := ltable.New().
 			Headers(columnNames...).
 			Rows(data...).

--- a/table/options.go
+++ b/table/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	Widths          []int    `short:"w" help:"Column widths"`
 	Height          int      `help:"Table height" default:"0"`
 	Print           bool     `short:"p" help:"static print" default:"false"`
+	Interactive     bool     `short:"i" help:"force interactive mode when stdout is not a terminal" default:"false"`
 	File            string   `short:"f" help:"file path" default:""`
 	Border          string   `short:"b" help:"border style" default:"rounded" enum:"rounded,thick,normal,hidden,double,none"`
 	ShowHelp        bool     `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_TABLE_SHOW_HELP"`


### PR DESCRIPTION
Fixes #800 

### Changes
- Add `--interactive/-i` flag to restore previous functionality to select a table row then pipe it into another command
