### PR TITLE
chore(nix): update src hash and nix version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,11 +2,11 @@
 
 pkgs.buildGoModule rec {
   pname = "gum";
-  version = "0.14.0";
+  version = "0.15.0";
 
   src = ./.;
 
-  vendorHash = "sha256-UNBDVIz2VEizkhelCjadkzd2S2yTYXecTFUpCf+XtxY=";
+  vendorHash = "sha256-i/KBe41ufYA+tqnB5LCC1geIc2Jnh97JLXcXfBgxdM4=";
 
   ldflags = [ "-s" "-w" "-X=main.Version=${version}" ];
 }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715447595,
-        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Changes
- changed src hash to make main branch build through nix 
- change version to 0.15.0
- update nix lock file to have go >= 1.23 instead of 1.22.2
