### PR TITLE
feat(write): allow custom keybinds

### DIFF
--- a/write/command.go
+++ b/write/command.go
@@ -16,10 +16,34 @@ import (
 
 // Run provides a shell script interface for the text area bubble.
 // https://github.com/charmbracelet/bubbles/textarea
+var Keybinds map[string]string
+
 func (o Options) Run() error {
 	in, _ := stdin.Read(stdin.StripANSI(o.StripANSI))
 	if in != "" && o.Value == "" {
 		o.Value = strings.ReplaceAll(in, "\r", "")
+	}
+
+	Keybinds = map[string]string {
+		"InsertNewline": "ctrl+j",
+		"Quit": "esc",
+		"Abort": "ctrl+c",
+		"OpenInEditor": "ctrl+e",
+		"Submit": "enter",
+	}
+
+	rebinds := map[string]string {
+		"InsertNewline": o.BindInsertNewline,
+		"Quit": o.BindQuit,
+		"Abort": o.BindAbort,
+		"OpenInEditor": o.BindOpenInEditor,
+		"Submit": o.BindSubmit,
+	}
+
+	for key, value := range rebinds {
+		if value != "" {
+			Keybinds[key] = value
+		}
 	}
 
 	a := textarea.New()

--- a/write/options.go
+++ b/write/options.go
@@ -23,6 +23,12 @@ type Options struct {
 	Timeout         time.Duration `help:"Timeout until choose returns selected element" default:"0s" env:"GUM_WRITE_TIMEOUT"`
 	StripANSI       bool          `help:"Strip ANSI sequences when reading from STDIN" default:"true" negatable:"" env:"GUM_WRITE_STRIP_ANSI"`
 
+	BindInsertNewline string      `help:"Change keybind to insert new line" default:"ctrl+j"`
+	BindQuit          string      `help:"Change keybind to quit" default:"esc"`
+	BindAbort         string      `help:"Change keybind to abort" default:"ctrl+c"`
+	BindOpenInEditor  string      `help:"Change keybind to open in editor" default:"ctrl+e"`
+	BindSubmit        string      `help:"Change keybind to submit" default:"enter"`
+
 	BaseStyle             style.Styles `embed:"" prefix:"base." envprefix:"GUM_WRITE_BASE_"`
 	CursorLineNumberStyle style.Styles `embed:"" prefix:"cursor-line-number." set:"defaultForeground=7" envprefix:"GUM_WRITE_CURSOR_LINE_NUMBER_"`
 	CursorLineStyle       style.Styles `embed:"" prefix:"cursor-line." envprefix:"GUM_WRITE_CURSOR_LINE_"`

--- a/write/write.go
+++ b/write/write.go
@@ -43,26 +43,26 @@ func (k keymap) ShortHelp() []key.Binding {
 func defaultKeymap() keymap {
 	km := textarea.DefaultKeyMap
 	km.InsertNewline = key.NewBinding(
-		key.WithKeys("ctrl+j"),
-		key.WithHelp("ctrl+j", "insert newline"),
+		key.WithKeys(Keybinds["InsertNewline"]),
+		key.WithHelp(Keybinds["InsertNewline"], "insert newline"),
 	)
 	return keymap{
 		KeyMap: km,
 		Quit: key.NewBinding(
-			key.WithKeys("esc"),
-			key.WithHelp("esc", "quit"),
+			key.WithKeys(Keybinds["Quit"]),
+			key.WithHelp(Keybinds["Quit"], "quit"),
 		),
 		Abort: key.NewBinding(
-			key.WithKeys("ctrl+c"),
-			key.WithHelp("ctrl+c", "cancel"),
+			key.WithKeys(Keybinds["Abort"]),
+			key.WithHelp(Keybinds["Abort"], "cancel"),
 		),
 		OpenInEditor: key.NewBinding(
-			key.WithKeys("ctrl+e"),
-			key.WithHelp("ctrl+e", "open editor"),
+			key.WithKeys(Keybinds["OpenInEditor"]),
+			key.WithHelp(Keybinds["OpenInEditor"], "open editor"),
 		),
 		Submit: key.NewBinding(
-			key.WithKeys("enter"),
-			key.WithHelp("enter", "submit"),
+			key.WithKeys(Keybinds["Submit"]),
+			key.WithHelp(Keybinds["Submit"], "submit"),
 		),
 	}
 }


### PR DESCRIPTION
i used to insert newline with alt+enter. this stopped working all of a sudden, probably related to [this](https://github.com/charmbracelet/gum/issues/817)

so i thought it would be cool to give the user the ability to customize keybinds