### PR TITLE
Update FreeBSD installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ sudo zypper install gum
 
 </details>
 
+<details>
+<summary>FreeBSD</summary>
+
+```bash
+# packages
+sudo pkg install gum
+
+# ports
+cd /usr/ports/devel/gum && sudo make install clean
+```
+
+</details>
+
 Or download it:
 
 - [Packages][releases] are available in Debian, RPM, and Alpine formats


### PR DESCRIPTION
I am the maintainer of the FreeBSD port for gum.  Gum can now be installed natively in FreeBSD using either packages or ports.

### Changes
- Add native installation instructions for FreeBSD.
