### PR TITLE
fix(pager): memory/cpu usage when using soft-wrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.7.0
 	github.com/charmbracelet/x/editor v0.1.0
 	github.com/charmbracelet/x/term v0.2.1
-	github.com/muesli/reflow v0.3.0
 	github.com/muesli/roff v0.1.0
 	github.com/muesli/termenv v0.15.3-0.20241211131612-0d230cb6eb15
 	github.com/rivo/uniseg v0.4.7
@@ -40,6 +39,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/mango v0.2.0 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect


### PR DESCRIPTION
easily reproducible, especially with something like

```sh
PAGER="gum pager" man ls
```

Problems here were:
- reflow's truncate is not very efficient
- useless calls to truncate
- bad strings.Replace calls (not necessary, and wouldn't work if text has ansi sequences)

Fixes #823 

PS: this is better handled in #791, but that one is a bigger change (and depends on a /bubbles change as well), so I think we can probably do this instead for now and push a patch until #791 is done and merged.

---

#### before:

![CleanShot 2025-01-28 at 11 24 21@2x](https://github.com/user-attachments/assets/2216c05f-4de9-47a1-ad04-dbe2e7878844)


#### fixed on regular usage, search still broken

![image](https://github.com/user-attachments/assets/e2fc1ace-7686-4c2d-bbc5-2f54fdfd1f8a)


#### full fix

![image](https://github.com/user-attachments/assets/f2257181-5ff6-48a2-ad43-fbaa087750e9)
