### PR TITLE
fix: generated completion invalid for fish shell

### DIFF
--- a/filter/options.go
+++ b/filter/options.go
@@ -15,7 +15,7 @@ type Options struct {
 	Limit                 int           `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit               bool          `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
 	SelectIfOne           bool          `help:"Select the given option if there is only one" group:"Selection"`
-	Selected              []string      `help:"Options that should start as selected (selects all if given '*')" default:"" env:"GUM_FILTER_SELECTED"`
+	Selected              []string      `help:"Options that should start as selected (selects all if given *)" default:"" env:"GUM_FILTER_SELECTED"`
 	ShowHelp              bool          `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_FILTER_SHOW_HELP"`
 	Strict                bool          `help:"Only returns if anything matched. Otherwise return Filter" negatable:"" default:"true" group:"Selection"`
 	SelectedPrefix        string        `help:"Character to indicate selected items (hidden if limit is 1)" default:" ◉ " env:"GUM_FILTER_SELECTED_PREFIX"`


### PR DESCRIPTION
Fixes #821 

Removes `'` from description, it also didn't match with the other description values