### PR TITLE
feat: show indicator on help keybindings (opt-in)

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -144,6 +144,7 @@ func (o Options) Run() error {
 	m := model{
 		table:    table,
 		showHelp: o.ShowHelp,
+		hideIndicator: o.HideIndicator,
 		help:     help.New(),
 		keymap:   defaultKeymap(),
 	}

--- a/table/command.go
+++ b/table/command.go
@@ -142,11 +142,11 @@ func (o Options) Run() error {
 	defer cancel()
 
 	m := model{
-		table:    table,
-		showHelp: o.ShowHelp,
+		table:         table,
+		showHelp:      o.ShowHelp,
 		hideIndicator: o.HideIndicator,
-		help:     help.New(),
-		keymap:   defaultKeymap(),
+		help:          help.New(),
+		keymap:        defaultKeymap(),
 	}
 	tm, err := tea.NewProgram(
 		m,

--- a/table/options.go
+++ b/table/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	File            string   `short:"f" help:"file path" default:""`
 	Border          string   `short:"b" help:"border style" default:"rounded" enum:"rounded,thick,normal,hidden,double,none"`
 	ShowHelp        bool     `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_TABLE_SHOW_HELP"`
+	HideIndicator   bool     `help:"Hide indicator on help keybinds" default:"false" negatable:"" env:"GUM_TABLE_HIDE_INDICATOR"`
 	LazyQuotes      bool     `help:"If LazyQuotes is true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field" default:"false" env:"GUM_TABLE_LAZY_QUOTES"`
 	FieldsPerRecord int      `help:"Sets the number of expected fields per record" default:"0" env:"GUM_TABLE_FIELDS_PER_RECORD"`
 

--- a/table/table.go
+++ b/table/table.go
@@ -15,6 +15,8 @@
 package table
 
 import (
+	"fmt"
+
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/table"
@@ -62,15 +64,24 @@ func defaultKeymap() keymap {
 }
 
 type model struct {
-	table    table.Model
-	selected table.Row
-	quitting bool
-	showHelp bool
-	help     help.Model
-	keymap   keymap
+	table         table.Model
+	selected      table.Row
+	quitting      bool
+	showHelp      bool
+	hideIndicator bool
+	help          help.Model
+	keymap        keymap
 }
 
 func (m model) Init() tea.Cmd { return nil }
+
+func (m model) inidicatorView() string {
+	if m.hideIndicator {
+		return ""
+	}
+
+	return m.help.Styles.FullDesc.Render(fmt.Sprintf("%d/%d%s", m.table.Cursor()+1, len(m.table.Rows()), m.help.ShortSeparator))
+}
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
@@ -102,7 +113,7 @@ func (m model) View() string {
 	}
 	s := m.table.View()
 	if m.showHelp {
-		s += "\n" + m.help.View(m.keymap)
+		s += "\n" + m.inidicatorView() + m.help.View(m.keymap)
 	}
 	return s
 }


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/gum/issues/196

This allow table display to be configurable and show item quantity on helper. It can be disabled by `hideIndicator`.

## Before

<img width="731" alt="Screenshot 2025-02-03 at 15 05 35" src="https://github.com/user-attachments/assets/2c43ee22-2a57-4af2-8b8d-edd1874fd754" />

## After

<img width="740" alt="Screenshot 2025-02-04 at 11 39 49" src="https://github.com/user-attachments/assets/fb8db0e8-dc13-40b1-bfb4-f5a53c1fd0dc" />
