### PR TITLE
fix(table): padding on item indicator

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -16,6 +16,7 @@ package table
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -80,7 +81,13 @@ func (m model) countView() string {
 		return ""
 	}
 
-	return m.help.Styles.FullDesc.Render(fmt.Sprintf("%d/%d%s", m.table.Cursor()+1, len(m.table.Rows()), m.help.ShortSeparator))
+	padding := strconv.Itoa(numLen(len(m.table.Rows())))
+	return m.help.Styles.FullDesc.Render(fmt.Sprintf(
+		"%"+padding+"d/%d%s",
+		m.table.Cursor()+1,
+		len(m.table.Rows()),
+		m.help.ShortSeparator,
+	))
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -116,4 +123,16 @@ func (m model) View() string {
 		s += "\n" + m.countView() + m.help.View(m.keymap)
 	}
 	return s
+}
+
+func numLen(i int) int {
+	if i == 0 {
+		return 1
+	}
+	count := 0
+	for i != 0 {
+		i /= 10
+		count++
+	}
+	return count
 }


### PR DESCRIPTION
this prevents the help view from moving once you pass item 10 (or 100, or 1000, etc):


#### before:
![CleanShot 2025-02-04 at 16 23 10@2x](https://github.com/user-attachments/assets/95a1a7bc-348a-4039-beba-f2103ecf7451)

#### after:
![CleanShot 2025-02-04 at 16 16 17@2x](https://github.com/user-attachments/assets/57730b5d-f05c-4177-95fb-ea6e88d0091e)
