### PR TITLE
fix(table): update StyleFunc to apply header style correctly

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -116,7 +116,7 @@ func (o Options) Run() error {
 			BorderStyle(o.BorderStyle.ToLipgloss()).
 			Border(style.Border[o.Border]).
 			StyleFunc(func(row, _ int) lipgloss.Style {
-				if row == 0 {
+				if row == ltable.HeaderRow {
 					return styles.Header
 				}
 				return styles.Cell


### PR DESCRIPTION
The `StyleFunc` in the `Lipgloss` table now correctly returns the header style only when the row is equal to `HeaderRow` (-1). Previously, it applied the header style when the row was 0, which actually corresponds to the first row of the table, not the header.

The behavior of the `StyleFunc` in `Lipgloss` table has changed as outlined in this PR: https://github.com/charmbracelet/lipgloss/pull/377

Fixes #833

### Changes
- Updated `StyleFunc` to apply the header style only when the row is equal to `HeaderRow` (-1), instead of 0.
