### PR TITLE
fix wildcard escaping issue 

### DIFF
--- a/completion/fish.go
+++ b/completion/fish.go
@@ -79,7 +79,7 @@ func (f Fish) gen(buf io.StringWriter, cmd *kong.Node) {
 			_, _ = buf.WriteString(fmt.Sprintf(" -s %c", f.Short))
 		}
 		_, _ = buf.WriteString(fmt.Sprintf(" -l %s", f.Name))
-		_, _ = buf.WriteString(fmt.Sprintf(" -d '%s'", f.Help))
+		_, _ = buf.WriteString(fmt.Sprintf(" -d "%s", f.Help))
 		_, _ = buf.WriteString("\n")
 	}
 	_, _ = buf.WriteString("\n")

--- a/completion/fish.go
+++ b/completion/fish.go
@@ -79,7 +79,7 @@ func (f Fish) gen(buf io.StringWriter, cmd *kong.Node) {
 			_, _ = buf.WriteString(fmt.Sprintf(" -s %c", f.Short))
 		}
 		_, _ = buf.WriteString(fmt.Sprintf(" -l %s", f.Name))
-		_, _ = buf.WriteString(fmt.Sprintf(" -d "%s", f.Help))
+		_, _ = buf.WriteString(fmt.Sprintf(" -d \"%s\"", f.Help))
 		_, _ = buf.WriteString("\n")
 	}
 	_, _ = buf.WriteString("\n")


### PR DESCRIPTION
Fixes #...
fix the following error on fish completion:
```
No matches for wildcard ''Options that should start as selected (selects all if given '*')''. See `help wildcards-globbing`.
complete -c gum -f -n '__fish_seen_subcommand_from filter' -x -l selected -d 'Options that should start as selected (selects all if given '*')'
```
### Changes
 
-
