### PR TITLE
Detect timeout error and apply default option

### DIFF
--- a/confirm/command.go
+++ b/confirm/command.go
@@ -1,6 +1,7 @@
 package confirm
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -46,7 +47,7 @@ func (o Options) Run() error {
 		tea.WithOutput(os.Stderr),
 		tea.WithContext(ctx),
 	).Run()
-	if err != nil {
+	if err != nil && ctx.Err() != context.DeadlineExceeded {
 		return fmt.Errorf("unable to confirm: %w", err)
 	}
 	m = tm.(model)


### PR DESCRIPTION
This is a quick fix to prove the point made here https://github.com/charmbracelet/gum/issues/876#issuecomment-2792207961 about the timeout condition not being handled properly at the moment 
