### PR TITLE
fix(choose)!: Rename environment variable `GUM_CCHOOSE_TIMEOUT` to `GUM_CHOOSE_TIMEOUT`

### DIFF
--- a/choose/options.go
+++ b/choose/options.go
@@ -15,7 +15,7 @@ type Options struct {
 	Height           int           `help:"Height of the list" default:"10" env:"GUM_CHOOSE_HEIGHT"`
 	Cursor           string        `help:"Prefix to show on item that corresponds to the cursor position" default:"> " env:"GUM_CHOOSE_CURSOR"`
 	ShowHelp         bool          `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_CHOOSE_SHOW_HELP"`
-	Timeout          time.Duration `help:"Timeout until choose returns selected element" default:"0s" env:"GUM_CCHOOSE_TIMEOUT"` // including timeout command options [Timeout,...]
+	Timeout          time.Duration `help:"Timeout until choose returns selected element" default:"0s" env:"GUM_CHOOSE_TIMEOUT"` // including timeout command options [Timeout,...]
 	Header           string        `help:"Header value" default:"Choose:" env:"GUM_CHOOSE_HEADER"`
 	CursorPrefix     string        `help:"Prefix to show on the cursor item (hidden if limit is 1)" default:"• " env:"GUM_CHOOSE_CURSOR_PREFIX"`
 	SelectedPrefix   string        `help:"Prefix to show on selected items (hidden if limit is 1)" default:"✓ " env:"GUM_CHOOSE_SELECTED_PREFIX"`


### PR DESCRIPTION
### Changes
- :exclamation: **BREAKING CHANGE**: Rename environment variable `GUM_CCHOOSE_TIMEOUT` to `GUM_CHOOSE_TIMEOUT` 

This fixes the typo in the environment variable name.
Technically a breaking change because the old environment variable won't work anymore.

### Test
- Run `export GUM_CCHOOSE_TIMEOUT=1s`  
- Run `export GUM_CHOOSE_TIMEOUT=10s`  
- Run `gum choose 1 2 3` without this fix. It times out after 1 second.
- Run `gum choose 1 2 3` with this fix. It times out after 10 seconds.
