### PR TITLE
feat: allow tab (\t) as separator for tables

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/table"
@@ -40,7 +41,7 @@ func (o Options) Run() error {
 	reader.LazyQuotes = o.LazyQuotes
 	reader.FieldsPerRecord = o.FieldsPerRecord
 	separatorRunes := []rune(o.Separator)
-	if len(separatorRunes) != 1 {
+	if !strings.HasPrefix(o.Separator, "\\") && len(separatorRunes) != 1 {
 		return fmt.Errorf("separator must be single character")
 	}
 	reader.Comma = separatorRunes[0]


### PR DESCRIPTION
TSV is a popular variant of CSV that uses tabs as the separator char. `gum table` would not allow it to be used as the separator because it only allows single runes but tab must be given as an escape sequence.

This change allows escape sequeneces like `\t` to be used as the separator.
