### PR TITLE
feat: Adding --show-elapsed flag in spin command

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -21,14 +21,15 @@ func (o Options) Run() error {
 	s.Style = o.SpinnerStyle.ToLipgloss()
 	s.Spinner = spinnerMap[o.Spinner]
 	m := model{
-		spinner:    s,
-		title:      o.TitleStyle.ToLipgloss().Render(o.Title),
-		command:    o.Command,
-		align:      o.Align,
-		showStdout: (o.ShowOutput || o.ShowStdout) && isOutTTY,
-		showStderr: (o.ShowOutput || o.ShowStderr) && isErrTTY,
-		showError:  o.ShowError,
-		isTTY:      isErrTTY,
+		spinner:     s,
+		title:       o.TitleStyle.ToLipgloss().Render(o.Title),
+		command:     o.Command,
+		align:       o.Align,
+		showStdout:  (o.ShowOutput || o.ShowStdout) && isOutTTY,
+		showStderr:  (o.ShowOutput || o.ShowStderr) && isErrTTY,
+		showError:   o.ShowError,
+		showElapsed: o.ShowElapsed,
+		isTTY:       isErrTTY,
 	}
 
 	ctx, cancel := timeout.Context(o.Timeout)

--- a/spin/options.go
+++ b/spin/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	ShowError    bool          `help:"Show output of command only if the command fails" default:"false" env:"GUM_SPIN_SHOW_ERROR"`
 	ShowStdout   bool          `help:"Show STDOUT output" default:"false" env:"GUM_SPIN_SHOW_STDOUT"`
 	ShowStderr   bool          `help:"Show STDERR errput" default:"false" env:"GUM_SPIN_SHOW_STDERR"`
+	ShowElapsed  bool          `help:"Show elapsed timer" default:"false"`
 	Spinner      string        `help:"Spinner type" short:"s" type:"spinner" enum:"line,dot,minidot,jump,pulse,points,globe,moon,monkey,meter,hamburger" default:"dot" env:"GUM_SPIN_SPINNER"`
 	SpinnerStyle style.Styles  `embed:"" prefix:"spinner." set:"defaultForeground=212" envprefix:"GUM_SPIN_SPINNER_"`
 	Title        string        `help:"Text to display to user while spinning" default:"Loading..." env:"GUM_SPIN_TITLE"`


### PR DESCRIPTION
Fixes #951 

### Changes
- adds a --show-elapsed flag that shows elapsed time.

<img width="559" height="108" alt="image" src="https://github.com/user-attachments/assets/e30c15db-b3db-41fc-ac14-59bdfc4586b5" />
<img width="559" height="108" alt="image" src="https://github.com/user-attachments/assets/efa8a3ae-f69c-45f5-8647-f13d30db871b" />

``` go
	return fmt.Sprintf("(%dd %dh %dm)", days, hours, minutes)
	
	return fmt.Sprintf("(%dh %dm)", hours, minutes)
	
	return fmt.Sprintf("(%dm %ds)", minutes, seconds)

	return fmt.Sprintf("(%ds)", seconds)
```
These are the formats