### PR TITLE
feat(log): set style per level

### DIFF
--- a/log/command.go
+++ b/log/command.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
+	"charm.land/gum/v2/style"
 	"charm.land/lipgloss/v2"
-	log "charm.land/log/v2"
+	"charm.land/log/v2"
 )
 
 // Run is the command-line interface for logging text.
@@ -68,10 +70,7 @@ func (o Options) Run() error {
 
 	st := log.DefaultStyles()
 	lvl := levelToLog[o.Level]
-	lvlStyle := o.LevelStyle.ToLipgloss()
-	if _, isNoColor := lvlStyle.GetForeground().(lipgloss.NoColor); isNoColor {
-		lvlStyle = lvlStyle.Foreground(st.Levels[lvl].GetForeground())
-	}
+	lvlStyle := o.logToStyle(lvl, st)
 
 	st.Levels[lvl] = lvlStyle.
 		SetString(strings.ToUpper(lvl.String())).
@@ -140,10 +139,40 @@ type logger struct {
 }
 
 var levelToLog = map[string]log.Level{
-	"none":  log.Level(math.MaxInt32),
+	"none":  log.Level(math.MaxInt), // cf. unexported log.noLevel
 	"debug": log.DebugLevel,
 	"info":  log.InfoLevel,
 	"warn":  log.WarnLevel,
 	"error": log.ErrorLevel,
 	"fatal": log.FatalLevel,
+}
+
+func (o Options) logToStyle(level log.Level, defaults *log.Styles) lipgloss.Style {
+	levelStyle := style.Styles{}
+	switch level {
+	case log.Level(math.MaxInt32):
+	case log.DebugLevel:
+		levelStyle = o.LevelDebugStyle
+	case log.InfoLevel:
+		levelStyle = o.LevelInfoStyle
+	case log.WarnLevel:
+		levelStyle = o.LevelWarnStyle
+	case log.ErrorLevel:
+		levelStyle = o.LevelErrorStyle
+	case log.FatalLevel:
+		levelStyle = o.LevelFatalStyle
+	}
+
+	// NB: Empirically determined that _this_ is what we get if we pass no CLI/Env args
+	defaultLevelStyle := style.Styles{Align: "left", Bold: true, Border: "none", Margin: "0 0", Padding: "0 0"}
+	if reflect.DeepEqual(levelStyle, defaultLevelStyle) {
+		levelStyle = o.LevelStyle
+	}
+
+	lgStyle := levelStyle.ToLipgloss()
+	if _, isNoColor := lgStyle.GetForeground().(lipgloss.NoColor); isNoColor {
+		lgStyle = lgStyle.Foreground(defaults.Levels[level].GetForeground())
+	}
+
+	return lgStyle
 }

--- a/log/options.go
+++ b/log/options.go
@@ -18,11 +18,16 @@ type Options struct {
 
 	MinLevel string `help:"Minimal level to show" default:"" env:"GUM_LOG_LEVEL"`
 
-	LevelStyle     style.Styles `embed:"" prefix:"level." help:"The style of the level being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_"`
-	TimeStyle      style.Styles `embed:"" prefix:"time." help:"The style of the time" envprefix:"GUM_LOG_TIME_"`
-	PrefixStyle    style.Styles `embed:"" prefix:"prefix." help:"The style of the prefix" set:"defaultBold=true" set:"defaultFaint=true" envprefix:"GUM_LOG_PREFIX_"` //nolint:staticcheck
-	MessageStyle   style.Styles `embed:"" prefix:"message." help:"The style of the message" envprefix:"GUM_LOG_MESSAGE_"`
-	KeyStyle       style.Styles `embed:"" prefix:"key." help:"The style of the key" set:"defaultFaint=true" envprefix:"GUM_LOG_KEY_"`
-	ValueStyle     style.Styles `embed:"" prefix:"value." help:"The style of the value" envprefix:"GUM_LOG_VALUE_"`
-	SeparatorStyle style.Styles `embed:"" prefix:"separator." help:"The style of the separator" set:"defaultFaint=true" envprefix:"GUM_LOG_SEPARATOR_"`
+	LevelStyle      style.Styles `embed:"" prefix:"level." help:"The style of the level being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_"`
+	LevelDebugStyle style.Styles `embed:"" prefix:"level.debug." help:"The style of level 'debug' being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_DEBUG_"`
+	LevelInfoStyle  style.Styles `embed:"" prefix:"level.info." help:"The style of level 'info' being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_INFO_"`
+	LevelWarnStyle  style.Styles `embed:"" prefix:"level.warn." help:"The style of level 'warn' being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_WARN_"`
+	LevelErrorStyle style.Styles `embed:"" prefix:"level.error." help:"The style of level 'error' being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_ERROR_"`
+	LevelFatalStyle style.Styles `embed:"" prefix:"level.fatal." help:"The style of level 'fatal' being used" set:"defaultBold=true" envprefix:"GUM_LOG_LEVEL_FATAL_"`
+	TimeStyle       style.Styles `embed:"" prefix:"time." help:"The style of the time" envprefix:"GUM_LOG_TIME_"`
+	PrefixStyle     style.Styles `embed:"" prefix:"prefix." help:"The style of the prefix" set:"defaultBold=true" set:"defaultFaint=true" envprefix:"GUM_LOG_PREFIX_"` //nolint:staticcheck
+	MessageStyle    style.Styles `embed:"" prefix:"message." help:"The style of the message" envprefix:"GUM_LOG_MESSAGE_"`
+	KeyStyle        style.Styles `embed:"" prefix:"key." help:"The style of the key" set:"defaultFaint=true" envprefix:"GUM_LOG_KEY_"`
+	ValueStyle      style.Styles `embed:"" prefix:"value." help:"The style of the value" envprefix:"GUM_LOG_VALUE_"`
+	SeparatorStyle  style.Styles `embed:"" prefix:"separator." help:"The style of the separator" set:"defaultFaint=true" envprefix:"GUM_LOG_SEPARATOR_"`
 }


### PR DESCRIPTION
Fixes #944

### Changes
- add new options, one per log level
- use them


### Demonstration

<details>
<summary>Test Script</summary>

```bash
#!/usr/bin/env bash

mkdir -p out
go build -o out -v ./...

log_all_levels() {
  echo "---"
  out/gum log --level=none  "Nothing"
  out/gum log --level=debug "A Detail"
  out/gum log --level=info  "A Note"
  out/gum log --level=warn  "A Warning"
  out/gum log --level=error "An Error"
  out/gum log --level=fatal "A Fuckup"
  echo "---"
}

echo "Defaults:"
log_all_levels || true
echo ""

echo "Legacy:"
export GUM_LOG_LEVEL_FOREGROUND="#ea76cb"
env | grep GUM_LOG_LEVEL_
log_all_levels || true
echo ""

echo "Some customization, fallback to legacy:"
echo "Style per level:"
export GUM_LOG_LEVEL_DEBUG_FOREGROUND="#6c6f85"
export GUM_LOG_LEVEL_INFO_FOREGROUND="#6c6f85"
env | grep GUM_LOG_LEVEL_
log_all_levels || true
echo ""

echo "Style per level:"
export GUM_LOG_LEVEL_DEBUG_FOREGROUND="#6c6f85"
export GUM_LOG_LEVEL_INFO_FOREGROUND="#04a5e5"
export GUM_LOG_LEVEL_WARN_FOREGROUND="#df8e1d"
export GUM_LOG_LEVEL_ERROR_FOREGROUND="#dd7878"
export GUM_LOG_LEVEL_FATAL_FOREGROUND="#d20f39"
env | grep GUM_LOG_LEVEL_
log_all_levels || true
```

</details>

<img width="473" height="1015" alt="image" src="https://github.com/user-attachments/assets/2a90ab04-c83c-402d-9be7-89707182ebdb" />
