### PR TITLE
fix(file): use height parameter as max height

### DIFF
--- a/file/command.go
+++ b/file/command.go
@@ -51,6 +51,7 @@ func (o Options) Run() error {
 	m := model{
 		filepicker:  fp,
 		padding:     []int{top, right, bottom, left},
+		maxHeight:   o.Height,
 		showHelp:    o.ShowHelp,
 		help:        help.New(),
 		keymap:      defaultKeymap(),

--- a/file/file.go
+++ b/file/file.go
@@ -60,6 +60,7 @@ type model struct {
 	quitting     bool
 	showHelp     bool
 	padding      []int
+	maxHeight    int
 	help         help.Model
 	keymap       keymap
 }
@@ -69,11 +70,11 @@ func (m model) Init() tea.Cmd { return m.filepicker.Init() }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		height := msg.Height - m.padding[0] - m.padding[2]
+		height := m.maxHeight - m.padding[0] - m.padding[2]
 		if m.showHelp {
 			height -= lipgloss.Height(m.helpView())
 		}
-		m.filepicker.SetHeight(height)
+		m.filepicker.SetHeight(min(height, msg.Height))
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, keyAbort):


### PR DESCRIPTION
While adding the padding parameter to file, the component has been refactored to use `m.filepicker.SetHeight` instead of the deprecated property `m.filepicker.Height`. Since this change, the size has been calculated based on the window height, overriding the value passed with `--height`.

This adds a new `maxHeight` property to constrain the maximum height of the file picker to the value passed by `--height`. The current behaviour of constraining the height to the window height has been preserved.

Refs: 6045525

Fixes #969
