### PR TITLE
Fix debug log message in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ the [`charmbracelet/log`](https://github.com/charmbracelet/log) library.
 ```bash
 # Log some debug information.
 gum log --structured --level debug "Creating file..." name file.txt
-# DEBUG Unable to create file. name=temp.txt
+# DEBUG Creating file... name=file.txt
 
 # Log some error.
 gum log --structured --level error "Unable to create file." name file.txt
@@ -381,6 +381,7 @@ gum log --structured --level error "Unable to create file." name file.txt
 
 # Include a timestamp.
 gum log --time rfc822 --level error "Unable to create file."
+# 27 Oct 25 10:38 CET ERROR Unable to create file.
 ```
 
 See the Go [`time` package](https://pkg.go.dev/time#pkg-constants) for acceptable `--time` formats.


### PR DESCRIPTION
This pull request updates the usage examples in the `README.md` to better reflect the actual output and improve clarity for users of the `log` command.

Documentation improvements:

* Updated the debug log example to show the correct output message and file name, replacing "Unable to create file. name=temp.txt" with "Creating file... name=file.txt".
* Added an example output line for logging with a timestamp using the `--time rfc822` flag, demonstrating the expected format.