### PR TITLE
fix(filter): show input text when using --no-strict

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -205,7 +205,15 @@ func (m model) View() string {
 			s.WriteString(" ")
 		}
 
-		styledOption := m.choices[match.Str]
+		styledOption, present := m.choices[match.Str]
+		if !present {
+			// No styled option found, print the unstyled string instead
+			// This can happen when --no-strict is used, and we want to print the input as an option
+			s.WriteString(lineTextStyle.Render(match.Str))
+			s.WriteRune('\n')
+			continue
+		}
+
 		if len(match.MatchedIndexes) == 0 {
 			// No matches, just render the text.
 			s.WriteString(lineTextStyle.Render(styledOption))


### PR DESCRIPTION
This fixes `gum filter --no-strict` not showing the input string text as an option.

Before the fix:
```
> test
•
  examples/test.sh
  internal/stdin/stdin.go
  style/ascii_a.txt
  filter/filter_test.go
  ```
  
After the fix:
```
> test
• test
  examples/test.sh
  internal/stdin/stdin.go
  style/ascii_a.txt
  filter/filter_test.go
```

Related to #957, not a complete fix as I did not look into the `--value` flag.