### PR TITLE
fix(spin): apply timeout context to command execution

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -18,6 +18,9 @@ func (o Options) Run() error {
 	isOutTTY := term.IsTerminal(os.Stdout.Fd())
 	isErrTTY := term.IsTerminal(os.Stderr.Fd())
 
+	ctx, cancel := timeout.Context(o.Timeout)
+	defer cancel()
+
 	s := spinner.New()
 	s.Style = o.SpinnerStyle.ToLipgloss()
 	s.Spinner = spinnerMap[o.Spinner]
@@ -32,10 +35,8 @@ func (o Options) Run() error {
 		showError:  o.ShowError,
 		isTTY:      isErrTTY,
 		padding:    []int{top, right, bottom, left},
+		ctx:        ctx,
 	}
-
-	ctx, cancel := timeout.Context(o.Timeout)
-	defer cancel()
 
 	tm, err := tea.NewProgram(
 		m,


### PR DESCRIPTION
This pull request addresses a bug in the spin command where processes were not respecting the configured timeout. The fix ensures that command execution properly inherits the timeout context instead of creating a background context, preventing processes from running longer than specified.


You can reproduce issue with command:

```sh
gum spin --timeout=1s -- sleep 1h | wc
```