### PR TITLE
feat: add --allow-abort flag to choose and filter commands

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -163,6 +163,9 @@ func (o Options) Run() error {
 	}
 	m = tm.(model)
 	if !m.submitted {
+		if o.AllowAbort {
+			return nil
+		}
 		return errors.New("nothing selected")
 	}
 	if o.Ordered && o.Limit > 1 {

--- a/choose/options.go
+++ b/choose/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	UnselectedPrefix string        `help:"Prefix to show on unselected items (hidden if limit is 1)" default:"• " env:"GUM_CHOOSE_UNSELECTED_PREFIX"`
 	Selected         []string      `help:"Options that should start as selected (selects all if given *)" default:"" env:"GUM_CHOOSE_SELECTED"`
 	SelectIfOne      bool          `help:"Select the given option if there is only one" group:"Selection"`
+	AllowAbort       bool          `help:"Exit successfully (code 0, no error) if aborted without selection" group:"Selection"`
 	InputDelimiter   string        `help:"Option delimiter when reading from STDIN" default:"\n" env:"GUM_CHOOSE_INPUT_DELIMITER"`
 	OutputDelimiter  string        `help:"Option delimiter when writing to STDOUT" default:"\n" env:"GUM_CHOOSE_OUTPUT_DELIMITER"`
 	LabelDelimiter   string        `help:"Allows to set a delimiter, so options can be set as label:value" default:"" env:"GUM_CHOOSE_LABEL_DELIMITER"`

--- a/filter/command.go
+++ b/filter/command.go
@@ -150,6 +150,9 @@ func (o Options) Run() error {
 
 	m = tm.(model)
 	if !m.submitted {
+		if o.AllowAbort {
+			return nil
+		}
 		return errors.New("nothing selected")
 	}
 

--- a/filter/options.go
+++ b/filter/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	Limit                 int           `help:"Maximum number of options to pick" default:"1" group:"Selection"`
 	NoLimit               bool          `help:"Pick unlimited number of options (ignores limit)" group:"Selection"`
 	SelectIfOne           bool          `help:"Select the given option if there is only one" group:"Selection"`
+	AllowAbort            bool          `help:"Exit successfully (code 0, no error) if aborted without selection" group:"Selection"`
 	Selected              []string      `help:"Options that should start as selected (selects all if given *)" default:"" env:"GUM_FILTER_SELECTED"`
 	ShowHelp              bool          `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_FILTER_SHOW_HELP"`
 	Strict                bool          `help:"Only returns if anything matched. Otherwise return Filter" negatable:"" default:"true" group:"Selection"`


### PR DESCRIPTION
⚠️ Note: Automagically generated by with [Claude Code](https://claude.ai/code)

## Summary

- Add `--allow-abort` flag to `gum choose` command
- Add `--allow-abort` flag to `gum filter` command
- When set, aborting selection (pressing ESC) exits successfully with code 0 and no error message

## Motivation

Fixes #875

When using `gum choose` or `gum filter` in shell scripts, pressing ESC to cancel currently prints "nothing selected" to stderr and exits with code 1. This makes it difficult to handle the abort case gracefully in loops or when the user intentionally wants to cancel.

## Usage

```bash
# Exit cleanly (code 0, no error message) when user presses ESC
gum choose --allow-abort "Option 1" "Option 2" "Option 3"

gum filter --allow-abort < options.txt
```

This allows scripts to handle the "no selection" case differently:

```bash
choice=$(gum choose --allow-abort "a" "b" "c")
if [ -z "$choice" ]; then
    echo "User cancelled selection"
else
    echo "User selected: $choice"
fi
```

## Test plan

- [x] Build succeeds
- [x] Existing tests pass
- [x] `--allow-abort` flag appears in `gum choose --help`
- [x] `--allow-abort` flag appears in `gum filter --help`
