### PR TITLE
feat(file): add fuzzy find mode to file picker

### DIFF
--- a/file/command.go
+++ b/file/command.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/filepicker"
 	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/gum/internal/timeout"
 	"github.com/charmbracelet/gum/style"
@@ -26,6 +28,11 @@ func (o Options) Run() error {
 	path, err := filepath.Abs(o.Path)
 	if err != nil {
 		return fmt.Errorf("file not found: %w", err)
+	}
+
+	// Use fuzzy mode if enabled
+	if o.Fuzzy {
+		return o.runFuzzy(path)
 	}
 
 	fp := filepicker.New()
@@ -75,5 +82,94 @@ func (o Options) Run() error {
 	}
 
 	fmt.Println(m.selectedPath)
+	return nil
+}
+
+// runFuzzy runs the file picker in fuzzy search mode.
+func (o Options) runFuzzy(basePath string) error {
+	// Collect all files recursively
+	files, err := collectFiles(basePath, o.All)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	if len(files) == 0 {
+		return errors.New("no files found in directory")
+	}
+
+	// Build the list of file names for fuzzy matching
+	filteringNames := make([]string, len(files))
+	for i, f := range files {
+		filteringNames[i] = f.name
+	}
+
+	// Initialize text input
+	ti := textinput.New()
+	ti.Focus()
+	ti.Prompt = o.Prompt
+	ti.PromptStyle = o.PromptStyle.ToLipgloss()
+	ti.PlaceholderStyle = o.PlaceholderStyle.ToLipgloss()
+	ti.Placeholder = o.Placeholder
+
+	// Initialize viewport
+	v := viewport.New(0, o.Height)
+
+	// Initial matches (show all)
+	matches := matchAllFuzzy(filteringNames)
+
+	top, right, bottom, left := style.ParsePadding(o.Padding)
+	m := fuzzyModel{
+		textinput:        ti,
+		viewport:         &v,
+		files:            files,
+		filteringNames:   filteringNames,
+		matches:          matches,
+		cursor:           0,
+		header:           o.Header,
+		height:           o.Height,
+		padding:          []int{top, right, bottom, left},
+		showHelp:         o.ShowHelp,
+		showPermissions:  o.Permissions,
+		showSize:         o.Size,
+		dirAllowed:       o.Directory,
+		fileAllowed:      o.File,
+		basePath:         basePath,
+		headerStyle:      o.HeaderStyle.ToLipgloss(),
+		matchStyle:       o.MatchStyle.ToLipgloss(),
+		indicatorStyle:   o.IndicatorStyle.ToLipgloss(),
+		indicator:        o.Indicator,
+		cursorStyle:      o.CursorStyle.ToLipgloss(),
+		selectedStyle:    o.SelectedStyle.ToLipgloss(),
+		directoryStyle:   o.DirectoryStyle.ToLipgloss(),
+		fileStyle:        o.FileStyle.ToLipgloss(),
+		symlinkStyle:     o.SymlinkStyle.ToLipgloss(),
+		permissionsStyle: o.PermissionsStyle.ToLipgloss(),
+		fileSizeStyle:    o.FileSizeStyle.ToLipgloss(),
+		keymap:           defaultFuzzyKeymap(),
+		help:             help.New(),
+	}
+
+	ctx, cancel := timeout.Context(o.Timeout)
+	defer cancel()
+
+	options := []tea.ProgramOption{
+		tea.WithOutput(os.Stderr),
+		tea.WithContext(ctx),
+	}
+	if o.Height == 0 {
+		options = append(options, tea.WithAltScreen())
+	}
+
+	tm, err := tea.NewProgram(&m, options...).Run()
+	if err != nil {
+		return fmt.Errorf("unable to run fuzzy file picker: %w", err)
+	}
+
+	fm := tm.(fuzzyModel)
+	if fm.selectedPath == "" {
+		return errors.New("no file selected")
+	}
+
+	fmt.Println(fm.selectedPath)
 	return nil
 }

--- a/file/fuzzy.go
+++ b/file/fuzzy.go
@@ -1,0 +1,418 @@
+// Package file provides an interface to pick a file from a folder (tree).
+// This file implements the fuzzy find functionality for the file picker.
+package file
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/exp/ordered"
+	"github.com/dustin/go-humanize"
+	"github.com/rivo/uniseg"
+	"github.com/sahilm/fuzzy"
+)
+
+// fileEntry represents a file with its full path and display name.
+type fileEntry struct {
+	path    string
+	name    string
+	isDir   bool
+	mode    fs.FileMode
+	size    int64
+	symlink string
+}
+
+type fuzzyKeymap struct {
+	Down   key.Binding
+	Up     key.Binding
+	Submit key.Binding
+	Quit   key.Binding
+	Abort  key.Binding
+}
+
+func defaultFuzzyKeymap() fuzzyKeymap {
+	return fuzzyKeymap{
+		Down: key.NewBinding(
+			key.WithKeys("down", "ctrl+j", "ctrl+n"),
+			key.WithHelp("down", "next"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "ctrl+k", "ctrl+p"),
+			key.WithHelp("up", "prev"),
+		),
+		Submit: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "select"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "quit"),
+		),
+		Abort: key.NewBinding(
+			key.WithKeys("ctrl+c"),
+			key.WithHelp("ctrl+c", "abort"),
+		),
+	}
+}
+
+// FullHelp implements help.KeyMap.
+func (k fuzzyKeymap) FullHelp() [][]key.Binding { return nil }
+
+// ShortHelp implements help.KeyMap.
+func (k fuzzyKeymap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		key.NewBinding(
+			key.WithKeys("up", "down"),
+			key.WithHelp("up/down", "navigate"),
+		),
+		k.Submit,
+		k.Quit,
+	}
+}
+
+type fuzzyModel struct {
+	textinput       textinput.Model
+	viewport        *viewport.Model
+	files           []fileEntry
+	filteringNames  []string
+	matches         []fuzzy.Match
+	cursor          int
+	header          string
+	height          int
+	padding         []int
+	quitting        bool
+	selectedPath    string
+	showHelp        bool
+	showPermissions bool
+	showSize        bool
+	dirAllowed      bool
+	fileAllowed     bool
+	basePath        string
+
+	// Styles
+	headerStyle      lipgloss.Style
+	matchStyle       lipgloss.Style
+	indicatorStyle   lipgloss.Style
+	indicator        string
+	cursorStyle      lipgloss.Style
+	selectedStyle    lipgloss.Style
+	directoryStyle   lipgloss.Style
+	fileStyle        lipgloss.Style
+	symlinkStyle     lipgloss.Style
+	permissionsStyle lipgloss.Style
+	fileSizeStyle    lipgloss.Style
+
+	keymap fuzzyKeymap
+	help   help.Model
+}
+
+func (m fuzzyModel) Init() tea.Cmd { return textinput.Blink }
+
+func (m fuzzyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd, icmd tea.Cmd
+	m.textinput, icmd = m.textinput.Update(msg)
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		if m.height == 0 || m.height > msg.Height {
+			m.viewport.Height = msg.Height - lipgloss.Height(m.textinput.View())
+		}
+		if m.header != "" {
+			m.viewport.Height -= lipgloss.Height(m.headerStyle.Render(m.header))
+		}
+		if m.showHelp {
+			m.viewport.Height -= lipgloss.Height(m.helpView())
+		}
+		m.viewport.Height -= m.padding[0] + m.padding[2]
+		m.viewport.Width = msg.Width - m.padding[1] - m.padding[3]
+		m.textinput.Width = msg.Width - m.padding[1] - m.padding[3]
+
+	case tea.KeyMsg:
+		km := m.keymap
+		switch {
+		case key.Matches(msg, km.Abort):
+			m.quitting = true
+			return m, tea.Interrupt
+		case key.Matches(msg, km.Quit):
+			m.quitting = true
+			return m, tea.Quit
+		case key.Matches(msg, km.Submit):
+			if len(m.matches) > 0 && m.cursor < len(m.matches) {
+				match := m.matches[m.cursor]
+				entry := m.findFileByName(match.Str)
+				if entry != nil {
+					if (entry.isDir && m.dirAllowed) || (!entry.isDir && m.fileAllowed) {
+						m.selectedPath = entry.path
+						m.quitting = true
+						return m, tea.Quit
+					}
+				}
+			}
+		case key.Matches(msg, km.Down):
+			m.cursorDown()
+		case key.Matches(msg, km.Up):
+			m.cursorUp()
+		default:
+			// Text input changed, update matches
+			m.matches = fuzzy.Find(m.textinput.Value(), m.filteringNames)
+			if m.textinput.Value() == "" {
+				m.matches = matchAllFuzzy(m.filteringNames)
+			}
+		}
+	}
+
+	m.cursor = ordered.Clamp(m.cursor, 0, len(m.matches)-1)
+	return m, tea.Batch(cmd, icmd)
+}
+
+func (m *fuzzyModel) cursorDown() {
+	if len(m.matches) == 0 {
+		return
+	}
+	m.cursor = (m.cursor + 1) % len(m.matches)
+	if m.cursor >= m.viewport.YOffset+m.viewport.Height {
+		m.viewport.ScrollDown(1)
+	}
+	if m.cursor < m.viewport.YOffset {
+		m.viewport.GotoTop()
+	}
+}
+
+func (m *fuzzyModel) cursorUp() {
+	if len(m.matches) == 0 {
+		return
+	}
+	m.cursor = (m.cursor - 1 + len(m.matches)) % len(m.matches)
+	if m.cursor < m.viewport.YOffset {
+		m.viewport.ScrollUp(1)
+	}
+	if m.cursor >= m.viewport.YOffset+m.viewport.Height {
+		m.viewport.SetYOffset(len(m.matches) - m.viewport.Height)
+	}
+}
+
+func (m fuzzyModel) findFileByName(name string) *fileEntry {
+	for i := range m.files {
+		if m.files[i].name == name {
+			return &m.files[i]
+		}
+	}
+	return nil
+}
+
+func (m fuzzyModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	var s strings.Builder
+
+	for i := range m.matches {
+		match := m.matches[i]
+		entry := m.findFileByName(match.Str)
+		if entry == nil {
+			continue
+		}
+
+		// Indicator for current selection
+		if i == m.cursor {
+			s.WriteString(m.indicatorStyle.Render(m.indicator))
+		} else {
+			s.WriteString(strings.Repeat(" ", lipgloss.Width(m.indicator)))
+		}
+
+		s.WriteString(" ")
+
+		// File info
+		var lineStyle lipgloss.Style
+		if entry.isDir {
+			lineStyle = m.directoryStyle
+		} else if entry.symlink != "" {
+			lineStyle = m.symlinkStyle
+		} else {
+			lineStyle = m.fileStyle
+		}
+
+		if i == m.cursor {
+			lineStyle = m.selectedStyle
+		}
+
+		// Build the display line
+		var line strings.Builder
+
+		if m.showPermissions {
+			line.WriteString(m.permissionsStyle.Render(entry.mode.String()))
+			line.WriteString(" ")
+		}
+
+		if m.showSize {
+			sizeStr := formatSize(entry.size)
+			line.WriteString(m.fileSizeStyle.Render(sizeStr))
+			line.WriteString(" ")
+		}
+
+		// Render name with match highlights
+		if len(match.MatchedIndexes) == 0 {
+			line.WriteString(lineStyle.Render(entry.name))
+		} else {
+			var ranges []lipgloss.Range
+			for _, rng := range matchedRangesFuzzy(match.MatchedIndexes) {
+				start, stop := bytePosToVisibleCharPosFuzzy(match.Str, rng)
+				ranges = append(ranges, lipgloss.NewRange(start, stop+1, m.matchStyle))
+			}
+			line.WriteString(lineStyle.Render(lipgloss.StyleRanges(entry.name, ranges...)))
+		}
+
+		if entry.symlink != "" {
+			line.WriteString(" -> ")
+			line.WriteString(entry.symlink)
+		}
+
+		s.WriteString(line.String())
+		s.WriteRune('\n')
+	}
+
+	m.viewport.SetContent(s.String())
+
+	// Build final view
+	header := m.headerStyle.Render(m.header)
+	view := m.textinput.View() + "\n" + m.viewport.View()
+	if m.showHelp {
+		view += m.helpView()
+	}
+	if m.header != "" {
+		return lipgloss.NewStyle().
+			Padding(m.padding...).
+			Render(header + "\n" + view)
+	}
+
+	return lipgloss.NewStyle().
+		Padding(m.padding...).
+		Render(view)
+}
+
+func (m fuzzyModel) helpView() string {
+	return "\n\n" + m.help.View(m.keymap)
+}
+
+func matchAllFuzzy(options []string) []fuzzy.Match {
+	matches := make([]fuzzy.Match, len(options))
+	for i, option := range options {
+		matches[i] = fuzzy.Match{Str: option}
+	}
+	return matches
+}
+
+func matchedRangesFuzzy(in []int) [][2]int {
+	if len(in) == 0 {
+		return [][2]int{}
+	}
+	current := [2]int{in[0], in[0]}
+	if len(in) == 1 {
+		return [][2]int{current}
+	}
+	var out [][2]int
+	for i := 1; i < len(in); i++ {
+		if in[i] == current[1]+1 {
+			current[1] = in[i]
+		} else {
+			out = append(out, current)
+			current = [2]int{in[i], in[i]}
+		}
+	}
+	out = append(out, current)
+	return out
+}
+
+func bytePosToVisibleCharPosFuzzy(str string, rng [2]int) (int, int) {
+	bytePos, byteStart, byteStop := 0, rng[0], rng[1]
+	pos, start, stop := 0, 0, 0
+	gr := uniseg.NewGraphemes(str)
+	for byteStart > bytePos {
+		if !gr.Next() {
+			break
+		}
+		bytePos += len(gr.Str())
+		pos += max(1, gr.Width())
+	}
+	start = pos
+	for byteStop > bytePos {
+		if !gr.Next() {
+			break
+		}
+		bytePos += len(gr.Str())
+		pos += max(1, gr.Width())
+	}
+	stop = pos
+	return start, stop
+}
+
+func formatSize(size int64) string {
+	sizeStr := humanize.Bytes(uint64(size)) //nolint:gosec
+	// Remove the space between number and unit for compactness
+	sizeStr = strings.Replace(sizeStr, " ", "", 1)
+	// Right-pad to 7 chars for alignment
+	return fmt.Sprintf("%7s", sizeStr)
+}
+
+// collectFiles recursively collects all files from the given path.
+func collectFiles(basePath string, showHidden bool) ([]fileEntry, error) {
+	var files []fileEntry
+
+	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // Skip files we can't access
+		}
+
+		// Skip the base path itself
+		if path == basePath {
+			return nil
+		}
+
+		name := d.Name()
+
+		// Skip hidden files if not showing them
+		if !showHidden && strings.HasPrefix(name, ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return nil // Skip files we can't get info for
+		}
+
+		entry := fileEntry{
+			path:  path,
+			name:  strings.TrimPrefix(path, basePath+string(os.PathSeparator)),
+			isDir: d.IsDir(),
+			mode:  info.Mode(),
+			size:  info.Size(),
+		}
+
+		// Check for symlink
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := filepath.EvalSymlinks(path)
+			if err == nil {
+				entry.symlink = target
+			}
+		}
+
+		files = append(files, entry)
+		return nil
+	})
+
+	return files, err
+}
+

--- a/file/options.go
+++ b/file/options.go
@@ -21,6 +21,16 @@ type Options struct {
 	Timeout     time.Duration `help:"Timeout until command aborts without a selection" default:"0s" env:"GUM_FILE_TIMEOUT"`
 	Header      string        `help:"Header value" default:"" env:"GUM_FILE_HEADER"`
 	Height      int           `help:"Maximum number of files to display" default:"10" env:"GUM_FILE_HEIGHT"`
+	Fuzzy       bool          `help:"Enable fuzzy filtering mode to search files by name" default:"false" env:"GUM_FILE_FUZZY"`
+
+	// Fuzzy mode styling options
+	Prompt           string       `help:"Prompt for fuzzy search input" default:"> " env:"GUM_FILE_PROMPT"`
+	Placeholder      string       `help:"Placeholder text for fuzzy search" default:"Search files..." env:"GUM_FILE_PLACEHOLDER"`
+	PromptStyle      style.Styles `embed:"" prefix:"prompt." set:"defaultForeground=240" envprefix:"GUM_FILE_PROMPT_"`
+	PlaceholderStyle style.Styles `embed:"" prefix:"placeholder." set:"defaultForeground=240" envprefix:"GUM_FILE_PLACEHOLDER_"`
+	MatchStyle       style.Styles `embed:"" prefix:"match." help:"The style to use for fuzzy match highlights" set:"defaultForeground=212" envprefix:"GUM_FILE_MATCH_"`
+	Indicator        string       `help:"Character for indicating selection in fuzzy mode" default:"•" env:"GUM_FILE_INDICATOR"`
+	IndicatorStyle   style.Styles `embed:"" prefix:"indicator." set:"defaultForeground=212" envprefix:"GUM_FILE_INDICATOR_"`
 
 	CursorStyle      style.Styles `embed:"" prefix:"cursor." help:"The cursor style" set:"defaultForeground=212" envprefix:"GUM_FILE_CURSOR_"`
 	SymlinkStyle     style.Styles `embed:"" prefix:"symlink." help:"The style to use for symlinks" set:"defaultForeground=36" envprefix:"GUM_FILE_SYMLINK_"`


### PR DESCRIPTION
## Summary

This PR adds fuzzy find capability to the file picker, addressing issue #603.

- Adds a new `--fuzzy` flag that enables fuzzy search mode for the file picker
- When enabled, users can type to filter files by name using fuzzy matching (similar to fzf)
- Recursively collects all files from the base directory and displays a searchable list
- Highlights matched characters in file names for visual feedback
- Supports customizable styling for prompts, matches, and indicators

### New Options

| Flag | Description | Default |
|------|-------------|---------|
| `--fuzzy` | Enable fuzzy filtering mode | `false` |
| `--prompt` | Search prompt text | `> ` |
| `--placeholder` | Placeholder text for search input | `Search files...` |
| `--indicator` | Character for selection indicator | `•` |
| `--prompt.*` | Style options for the prompt | |
| `--placeholder.*` | Style options for placeholder | |
| `--match.*` | Style options for match highlights | |
| `--indicator.*` | Style options for the indicator | |

### Usage Example

```bash
# Basic fuzzy file picker
gum file --fuzzy

# With hidden files
gum file --fuzzy --all

# Custom styling
gum file --fuzzy --match.foreground=green
```

## Test plan

- [ ] Test basic fuzzy search functionality with `gum file --fuzzy`
- [ ] Verify file selection works correctly (Enter key)
- [ ] Test with `--all` flag to include hidden files
- [ ] Test with `--directory` flag for directory selection
- [ ] Verify match highlighting displays correctly
- [ ] Test navigation with arrow keys
- [ ] Test quit with Esc and Ctrl+C
- [ ] Verify styling options work as expected

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)