### PR TITLE
feat(table): add multi-select with --limit and --no-limit

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -139,16 +139,31 @@ func (o Options) Run() error {
 
 	table := table.New(opts...)
 
+	limit := o.Limit
+	if o.NoLimit {
+		limit = len(rows) + 1
+	}
+
+	km := defaultKeymap()
+	if o.NoLimit || o.Limit > 1 {
+		km.Toggle.SetEnabled(true)
+	}
+	if o.NoLimit {
+		km.ToggleAll.SetEnabled(true)
+	}
+
 	ctx, cancel := timeout.Context(o.Timeout)
 	defer cancel()
 
 	m := model{
-		table:     table,
-		showHelp:  o.ShowHelp,
-		hideCount: o.HideCount,
-		help:      help.New(),
-		keymap:    defaultKeymap(),
-		padding:   []int{top, right, bottom, left},
+		table:       table,
+		limit:       limit,
+		selectedMap: make(map[int]struct{}),
+		showHelp:    o.ShowHelp,
+		hideCount:   o.HideCount,
+		help:        help.New(),
+		keymap:      km,
+		padding:     []int{top, right, bottom, left},
 	}
 	tm, err := tea.NewProgram(
 		m,
@@ -164,13 +179,36 @@ func (o Options) Run() error {
 	}
 
 	m = tm.(model)
-	if o.ReturnColumn > 0 && o.ReturnColumn <= len(m.selected) {
-		if err = writer.Write([]string{m.selected[o.ReturnColumn-1]}); err != nil {
-			return fmt.Errorf("failed to write col %d of selected row: %w", o.ReturnColumn, err)
+	if !m.submitted {
+		return fmt.Errorf("nothing selected")
+	}
+
+	// Multi-select: write all selected rows
+	if limit > 1 && m.numSelected > 0 {
+		for i, row := range rows {
+			if _, ok := m.selectedMap[i]; !ok {
+				continue
+			}
+			if o.ReturnColumn > 0 && o.ReturnColumn <= len(row) {
+				if err = writer.Write([]string{row[o.ReturnColumn-1]}); err != nil {
+					return fmt.Errorf("failed to write col %d of selected row: %w", o.ReturnColumn, err)
+				}
+			} else {
+				if err = writer.Write([]string(row)); err != nil {
+					return fmt.Errorf("failed to write selected row: %w", err)
+				}
+			}
 		}
 	} else {
-		if err = writer.Write([]string(m.selected)); err != nil {
-			return fmt.Errorf("failed to write selected row: %w", err)
+		// Single select (default behavior)
+		if o.ReturnColumn > 0 && o.ReturnColumn <= len(m.selected) {
+			if err = writer.Write([]string{m.selected[o.ReturnColumn-1]}); err != nil {
+				return fmt.Errorf("failed to write col %d of selected row: %w", o.ReturnColumn, err)
+			}
+		} else {
+			if err = writer.Write([]string(m.selected)); err != nil {
+				return fmt.Errorf("failed to write selected row: %w", err)
+			}
 		}
 	}
 

--- a/table/options.go
+++ b/table/options.go
@@ -24,6 +24,8 @@ type Options struct {
 	CellStyle     style.Styles  `embed:"" prefix:"cell." envprefix:"GUM_TABLE_CELL_"`
 	HeaderStyle   style.Styles  `embed:"" prefix:"header." envprefix:"GUM_TABLE_HEADER_"`
 	SelectedStyle style.Styles  `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_TABLE_SELECTED_"`
+	Limit         int           `help:"Maximum number of rows to select" default:"1" group:"Selection" env:"GUM_TABLE_LIMIT"`
+	NoLimit       bool          `help:"Pick unlimited number of rows (ignores limit)" group:"Selection" env:"GUM_TABLE_NO_LIMIT"`
 	ReturnColumn  int           `short:"r" help:"Which column number should be returned instead of whole row as string. Default=0 returns whole Row" default:"0"`
 	Timeout       time.Duration `help:"Timeout until choose returns selected element" default:"0s" env:"GUM_TABLE_TIMEOUT"`
 	Padding       string        `help:"Padding" default:"${defaultPadding}" group:"Style Flags" env:"GUM_TABLE_PADDING"`

--- a/table/table.go
+++ b/table/table.go
@@ -2,7 +2,7 @@
 // https://github.com/charmbracelet/bubbles/tree/master/table
 //
 // It is useful to render tabular (CSV) data in a terminal and allows
-// the user to select a row from the table.
+// the user to select one or more rows from the table.
 //
 // Let's render a table of gum flavors:
 //
@@ -28,6 +28,8 @@ import (
 type keymap struct {
 	Navigate,
 	Select,
+	Toggle,
+	ToggleAll,
 	Quit,
 	Abort key.Binding
 }
@@ -37,11 +39,18 @@ func (k keymap) FullHelp() [][]key.Binding { return nil }
 
 // ShortHelp implements help.KeyMap.
 func (k keymap) ShortHelp() []key.Binding {
-	return []key.Binding{
+	bindings := []key.Binding{
 		k.Navigate,
 		k.Select,
-		k.Quit,
 	}
+	if k.Toggle.Enabled() {
+		bindings = append(bindings, k.Toggle)
+	}
+	if k.ToggleAll.Enabled() {
+		bindings = append(bindings, k.ToggleAll)
+	}
+	bindings = append(bindings, k.Quit)
+	return bindings
 }
 
 func defaultKeymap() keymap {
@@ -53,6 +62,16 @@ func defaultKeymap() keymap {
 		Select: key.NewBinding(
 			key.WithKeys("enter"),
 			key.WithHelp("enter", "select"),
+		),
+		Toggle: key.NewBinding(
+			key.WithKeys(" ", "tab", "x"),
+			key.WithHelp("x", "toggle"),
+			key.WithDisabled(),
+		),
+		ToggleAll: key.NewBinding(
+			key.WithKeys("a", "A", "ctrl+a"),
+			key.WithHelp("ctrl+a", "select all"),
+			key.WithDisabled(),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("esc", "ctrl+q", "q"),
@@ -66,14 +85,18 @@ func defaultKeymap() keymap {
 }
 
 type model struct {
-	table     table.Model
-	selected  table.Row
-	quitting  bool
-	showHelp  bool
-	hideCount bool
-	help      help.Model
-	keymap    keymap
-	padding   []int
+	table       table.Model
+	selected    table.Row
+	selectedMap map[int]struct{} // tracks selected row indices for multi-select
+	limit       int
+	numSelected int
+	submitted   bool
+	quitting    bool
+	showHelp    bool
+	hideCount   bool
+	help        help.Model
+	keymap      keymap
+	padding     []int
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -99,8 +122,45 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		km := m.keymap
 		switch {
+		case key.Matches(msg, km.ToggleAll):
+			if m.limit <= 1 {
+				break
+			}
+			if m.numSelected < len(m.table.Rows()) && m.numSelected < m.limit {
+				// Select all (up to limit)
+				for i := range m.table.Rows() {
+					if m.numSelected >= m.limit {
+						break
+					}
+					if _, ok := m.selectedMap[i]; !ok {
+						m.selectedMap[i] = struct{}{}
+						m.numSelected++
+					}
+				}
+			} else {
+				// Deselect all
+				m.selectedMap = make(map[int]struct{})
+				m.numSelected = 0
+			}
+			return m, nil
+		case key.Matches(msg, km.Toggle):
+			if m.limit <= 1 {
+				break
+			}
+			cursor := m.table.Cursor()
+			if _, ok := m.selectedMap[cursor]; ok {
+				delete(m.selectedMap, cursor)
+				m.numSelected--
+			} else if m.numSelected < m.limit {
+				m.selectedMap[cursor] = struct{}{}
+				m.numSelected++
+			}
+			return m, nil
 		case key.Matches(msg, km.Select):
-			m.selected = m.table.SelectedRow()
+			if m.limit <= 1 {
+				m.selected = m.table.SelectedRow()
+			}
+			m.submitted = true
 			m.quitting = true
 			return m, tea.Quit
 		case key.Matches(msg, km.Quit):


### PR DESCRIPTION
Adds `--limit` and `--no-limit` flags to `gum table`, matching the behavior of `gum choose`.

**Usage:**

```bash
# Select up to 3 rows
gum table --limit 3 < data.csv

# Unlimited selection
gum table --no-limit < data.csv
```

When `--limit` > 1 or `--no-limit` is set:
- `space` / `tab` / `x` toggles the current row
- `ctrl+a` selects/deselects all (only with `--no-limit`)
- `enter` submits all selected rows

Default behavior (`--limit 1`) is unchanged -- enter selects the highlighted row, same as before.

Selected rows are written to stdout as CSV, one per line.

Closes #319