### PR TITLE
fix(file): account for header, lipgloss block join separators in internal filepicker spacing

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -69,11 +69,16 @@ func (m model) Init() tea.Cmd { return m.filepicker.Init() }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		height := msg.Height - m.padding[0] - m.padding[2]
+		fpHeight := msg.Height - m.padding[0] - m.padding[2]
+
+		// Account for newline used by lipgloss.JoinVertical
+		// to join filepicker block and help block together.
+		const SepHeight = 1
+
 		if m.showHelp {
-			height -= lipgloss.Height(m.helpView())
+			fpHeight -= SepHeight + lipgloss.Height(m.helpView())
 		}
-		m.filepicker.SetHeight(height)
+		m.filepicker.SetHeight(fpHeight)
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, keyAbort):

--- a/file/file.go
+++ b/file/file.go
@@ -75,6 +75,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// to join filepicker block and help block together.
 		const SepHeight = 1
 
+		if m.header != "" {
+			fpHeight -= lipgloss.Height(m.headerRender()) + SepHeight
+		}
+
 		if m.showHelp {
 			fpHeight -= SepHeight + lipgloss.Height(m.helpView())
 		}
@@ -105,7 +109,7 @@ func (m model) View() string {
 	}
 	var parts []string
 	if m.header != "" {
-		parts = append(parts, m.headerStyle.Render(m.header))
+		parts = append(parts, m.headerRender())
 	}
 	parts = append(parts, m.filepicker.View())
 	if m.showHelp {
@@ -121,4 +125,8 @@ func (m model) View() string {
 
 func (m model) helpView() string {
 	return m.help.View(m.keymap)
+}
+
+func (m model) headerRender() string {
+	return m.headerStyle.Render(m.header)
 }


### PR DESCRIPTION
Fixes #1025

In brief, this PR fixes an issue wherein the `View()` output of the `file` model is pushed up and out of view by one line. It also factors in spacing necessitated by the presence of a potential header. The issue link above lays out everything in far more detail (the "why," "how," et cetera).

It's worth noting that the fix relies _somewhat_ on an upstream `bubbles` fix; the `filepicker` package under v1.0.0 needs [this identical fix](https://github.com/charmbracelet/bubbles/pull/914). If that doesn't happen (and `gum`'s `go.mod` does not then use the new patch), `gum file` will instead then _overcompensate_ in granting cell space to the model's internal filepicker after merging this PR, allowing the shell command to remain rendered within the TUI.

In the very least, merging this PR does mean that `file` is functionally fixed, even if the first line gets a little crowded without the bubbles PR merge.

If desired, [this separate branch](https://github.com/bntrtm/gum/tree/demonstrate-internal-filepicker-fix) in my fork of gum demonstrates what this fix looks like in v1.0.0 alongside a (only somewhat unrelated) [bubbles(filepicker) v1 fix](https://github.com/charmbracelet/bubbles/pull/914). If you clone it and remove each addition of `SepHeight` under `filepicker/file.go`, you'll find that you run back into the exact issue that this PR resolves.