### PR TITLE
fix(choose): rename selected style prefix to avoid flag collision - C…

### DIFF
--- a/choose/options.go
+++ b/choose/options.go
@@ -31,5 +31,5 @@ type Options struct {
 	CursorStyle       style.Styles `embed:"" prefix:"cursor." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_CURSOR_"`
 	HeaderStyle       style.Styles `embed:"" prefix:"header." set:"defaultForeground=99" envprefix:"GUM_CHOOSE_HEADER_"`
 	ItemStyle         style.Styles `embed:"" prefix:"item." hidden:"" envprefix:"GUM_CHOOSE_ITEM_"`
-	SelectedItemStyle style.Styles `embed:"" prefix:"selected." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_"`
+	SelectedItemStyle style.Styles `embed:"" prefix:"selected-item." set:"defaultForeground=212" envprefix:"GUM_CHOOSE_SELECTED_ITEM_"`
 }

--- a/examples/git-branch-manager.sh
+++ b/examples/git-branch-manager.sh
@@ -15,9 +15,9 @@ git_color_text () {
 
 get_branches () {
   if [ ${1+x} ]; then
-    gum choose --selected.foreground="$GIT_COLOR" --limit="$1" $(git branch --format="%(refname:short)")
+    gum choose --selected-item.foreground="$GIT_COLOR" --limit="$1" $(git branch --format="%(refname:short)")
   else
-    gum choose --selected.foreground="$GIT_COLOR" --no-limit $(git branch --format="%(refname:short)")
+    gum choose --selected-item.foreground="$GIT_COLOR" --no-limit $(git branch --format="%(refname:short)")
   fi
 }
 

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -2,9 +2,9 @@
 
 # Choose
 gum choose Foo Bar Baz
-gum choose Choose One Item --cursor "* " --cursor.foreground 99 --selected.foreground 99
-gum choose Pick Two Items Maximum --limit 2 --cursor "* " --cursor-prefix "(•) " --selected-prefix "(x) " --unselected-prefix "( ) " --cursor.foreground 99 --selected.foreground 99
-gum choose Unlimited Choice Of Items --no-limit --cursor "* " --cursor-prefix "(•) " --selected-prefix "(x) " --unselected-prefix "( ) " --cursor.foreground 99 --selected.foreground 99
+gum choose Choose One Item --cursor "* " --cursor.foreground 99 --selected-item.foreground 99
+gum choose Pick Two Items Maximum --limit 2 --cursor "* " --cursor-prefix "(•) " --selected-prefix "(x) " --unselected-prefix "( ) " --cursor.foreground 99 --selected-item.foreground 99
+gum choose Unlimited Choice Of Items --no-limit --cursor "* " --cursor-prefix "(•) " --selected-prefix "(x) " --unselected-prefix "( ) " --cursor.foreground 99 --selected-item.foreground 99
 
 # Confirm
 gum confirm "Testing?"


### PR DESCRIPTION
Closes #1020

Fixes #1020

Changes
 - Renamed `selected.` style prefix to `selected-item.` to avoid flag collision.
 - Updated environment variable prefix to `GUM_CHOOSE_SELECTED_ITEM_`.
 - Updated `git-branch-manager.sh` and `test.sh` examples to use the new flag.