### PR TITLE
Fix spin command passthrough parsing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+)
+
+func TestSpinCommandParsesSpinnerAndCommandArgs(t *testing.T) {
+	gum := &Gum{}
+	parser, err := kong.New(gum, kong.Vars{
+		"version":                 "gum version test",
+		"versionNumber":           "test",
+		"defaultHeight":           "0",
+		"defaultWidth":            "0",
+		"defaultAlign":            "left",
+		"defaultBorder":           "none",
+		"defaultBorderForeground": "",
+		"defaultBorderBackground": "",
+		"defaultBackground":       "",
+		"defaultForeground":       "",
+		"defaultMargin":           "0 0",
+		"defaultPadding":          "0 0",
+		"defaultUnderline":        "false",
+		"defaultBold":             "false",
+		"defaultFaint":            "false",
+		"defaultItalic":           "false",
+		"defaultStrikethrough":    "false",
+	})
+	if err != nil {
+		t.Fatalf("failed to build parser: %v", err)
+	}
+
+	_, err = parser.Parse([]string{"spin", "--spinner", "monkey", "sleep", "5"})
+	if err != nil {
+		t.Fatalf("failed to parse spin command: %v", err)
+	}
+
+	if got, want := gum.Spin.Spinner, "monkey"; got != want {
+		t.Fatalf("spinner = %q, want %q", got, want)
+	}
+
+	if got, want := gum.Spin.Command, []string{"sleep", "5"}; len(got) != len(want) {
+		t.Fatalf("command length = %d, want %d (%v)", len(got), len(want), got)
+	} else {
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("command[%d] = %q, want %q (full command: %v)", i, got[i], want[i], got)
+			}
+		}
+	}
+}

--- a/spin/options.go
+++ b/spin/options.go
@@ -8,7 +8,7 @@ import (
 
 // Options is the customization options for the spin command.
 type Options struct {
-	Command []string `arg:"" help:"Command to run"`
+	Command []string `arg:"" passthrough:"" help:"Command to run"`
 
 	ShowOutput   bool          `help:"Show or pipe output of command during execution (shows both STDOUT and STDERR)" default:"false" env:"GUM_SPIN_SHOW_OUTPUT"`
 	ShowError    bool          `help:"Show output of command only if the command fails" default:"false" env:"GUM_SPIN_SHOW_ERROR"`


### PR DESCRIPTION
Fixes #1055

###Changes
~ allow gum spin to pass trailing command arguments through the CLI parser without requiring --
~ fix --spinner monkey and other spinner values when used as gum spin --spinner <name> <command>
~ add a regression test covering gum spin --spinner monkey sleep 5 parsing