### PR TITLE
Fix non-tty spin output handling

### DIFF
--- a/spin/command.go
+++ b/spin/command.go
@@ -2,6 +2,7 @@ package spin
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -37,9 +38,14 @@ func (o Options) Run() error {
 	ctx, cancel := timeout.Context(o.Timeout)
 	defer cancel()
 
+	teaOutput := io.Writer(os.Stderr)
+	if !isErrTTY {
+		teaOutput = io.Discard
+	}
+
 	tm, err := tea.NewProgram(
 		m,
-		tea.WithOutput(os.Stderr),
+		tea.WithOutput(teaOutput),
 		tea.WithContext(ctx),
 		tea.WithInput(nil),
 	).Run()

--- a/spin/command_test.go
+++ b/spin/command_test.go
@@ -1,0 +1,104 @@
+package spin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/gum/internal/exit"
+)
+
+func TestRunDoesNotPrintSuccessfulCommandOutputWithoutTTY(t *testing.T) {
+	withRedirectedStandardStreams(t, func(stdoutPath, stderrPath string) {
+		err := Options{
+			Command:   []string{"sh", "-c", "printf 'stdout'; printf 'stderr' >&2"},
+			ShowError: true,
+		}.Run()
+		if err != nil && !isExitCode(err, 0) {
+			t.Fatalf("Run() error = %v", err)
+		}
+
+		assertFileContents(t, stdoutPath, "")
+		assertFileContents(t, stderrPath, "")
+	})
+}
+
+func isExitCode(err error, code int) bool {
+	var ex exit.ErrExit
+	return errors.As(err, &ex) && int(ex) == code
+}
+
+func TestRunPrintsBufferedOutputOnFailureWithoutTTY(t *testing.T) {
+	withRedirectedStandardStreams(t, func(stdoutPath, stderrPath string) {
+		err := Options{
+			Command:   []string{"sh", "-c", "printf 'stdout'; printf 'stderr' >&2; exit 7"},
+			ShowError: true,
+		}.Run()
+
+		var ex exit.ErrExit
+		if !errors.As(err, &ex) || int(ex) != 7 {
+			t.Fatalf("Run() error = %v, want exit status 7", err)
+		}
+
+		assertFileContainsAll(t, stdoutPath, "stdout", "stderr")
+		assertFileContents(t, stderrPath, "")
+	})
+}
+
+func withRedirectedStandardStreams(t *testing.T, fn func(stdoutPath, stderrPath string)) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	stdoutFile, err := os.Create(filepath.Join(tmpDir, "stdout"))
+	if err != nil {
+		t.Fatalf("Create(stdout) error = %v", err)
+	}
+	defer stdoutFile.Close() //nolint:errcheck
+
+	stderrFile, err := os.Create(filepath.Join(tmpDir, "stderr"))
+	if err != nil {
+		t.Fatalf("Create(stderr) error = %v", err)
+	}
+	defer stderrFile.Close() //nolint:errcheck
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	os.Stdout = stdoutFile
+	os.Stderr = stderrFile
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	fn(stdoutFile.Name(), stderrFile.Name())
+}
+
+func assertFileContents(t *testing.T, path string, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	if got := string(data); got != want {
+		t.Fatalf("contents(%q) = %q, want %q", path, got, want)
+	}
+}
+
+func assertFileContainsAll(t *testing.T, path string, want ...string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+
+	got := string(data)
+	for _, part := range want {
+		if !strings.Contains(got, part) {
+			t.Fatalf("contents(%q) = %q, missing %q", path, got, part)
+		}
+	}
+}

--- a/spin/spin.go
+++ b/spin/spin.go
@@ -67,6 +67,10 @@ type finishCommandMsg struct {
 
 func commandStart(command []string) tea.Cmd {
 	return func() tea.Msg {
+		bothbuf.Reset()
+		outbuf.Reset()
+		errbuf.Reset()
+
 		var args []string
 		if len(command) > 1 {
 			args = command[1:]
@@ -75,17 +79,18 @@ func commandStart(command []string) tea.Cmd {
 		executing = exec.CommandContext(context.Background(), command[0], args...) //nolint:gosec
 		executing.Stdin = os.Stdin
 
-		isTerminal := term.IsTerminal(os.Stdout.Fd())
+		isStdoutTTY := term.IsTerminal(os.Stdout.Fd())
+		isStderrTTY := term.IsTerminal(os.Stderr.Fd())
 
 		// NOTE(@andreynering): We had issues with Git Bash on Windows
 		// when it comes to handling PTYs, so we're falling back to
 		// to redirecting stdout/stderr as usual to avoid issues.
 		//nolint:nestif
-		if isTerminal && runtime.GOOS == "windows" {
+		if runtime.GOOS == "windows" || !isStdoutTTY || !isStderrTTY {
 			executing.Stdout = io.MultiWriter(&bothbuf, &outbuf)
 			executing.Stderr = io.MultiWriter(&bothbuf, &errbuf)
 			_ = executing.Run()
-		} else if isTerminal {
+		} else {
 			stdoutPty, err := openPty(os.Stdout)
 			if err != nil {
 				return errorMsg(err)
@@ -112,10 +117,6 @@ func commandStart(command []string) tea.Cmd {
 				return errorMsg(err)
 			}
 			_ = xpty.WaitProcess(context.Background(), executing)
-		} else {
-			executing.Stdout = os.Stdout
-			executing.Stderr = os.Stderr
-			_ = executing.Run()
 		}
 
 		status := executing.ProcessState.ExitCode()
@@ -160,7 +161,7 @@ func (m model) View() string {
 	}
 
 	if !m.isTTY {
-		return m.title
+		return ""
 	}
 
 	var header string


### PR DESCRIPTION
Fixes #1011

### Changes

~ buffer command stdout and stderr during non-TTY gum spin execution instead of streaming child process output directly
~ keep --show-error silent for successful redirected runs, while still printing buffered output when the command fails
~ suppress spinner renderer output when stderr is not a TTY to avoid stray control sequences or title artifacts in redirected output