### PR TITLE
filter: keep strict mode open with no matches

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -303,6 +303,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.quitting = true
 			return m, tea.Interrupt
 		case key.Matches(msg, km.Submit):
+			if m.strict && len(m.matches) == 0 && len(m.selected) == 0 {
+				break
+			}
 			m.quitting = true
 			m.submitted = true
 			return m, tea.Quit

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -4,7 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/sahilm/fuzzy"
 )
 
 func TestMatchedRanges(t *testing.T) {
@@ -55,5 +58,46 @@ func TestByteToChar(t *testing.T) {
 	start, stop := bytePosToVisibleCharPos(str, rng)
 	if got := ansi.Strip(ansi.Cut(stStr, start, stop)); got != expect {
 		t.Errorf("expected %+q, got %+q", expect, got)
+	}
+}
+
+func TestStrictSubmitRequiresMatch(t *testing.T) {
+	m := model{
+		textinput: textinput.New(),
+		keymap:    defaultKeymap(),
+		strict:    true,
+	}
+	m.textinput.SetValue("zzz")
+
+	got, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if updated.submitted {
+		t.Fatal("expected strict mode to keep running when there are no matches")
+	}
+	if updated.quitting {
+		t.Fatal("expected strict mode to stay open when there are no matches")
+	}
+}
+
+func TestStrictSubmitStillWorksWithMatches(t *testing.T) {
+	m := model{
+		textinput: textinput.New(),
+		keymap:    defaultKeymap(),
+		strict:    true,
+		matches: []fuzzy.Match{
+			{Str: "banana"},
+		},
+	}
+	m.textinput.SetValue("ban")
+
+	got, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := got.(model)
+
+	if !updated.submitted {
+		t.Fatal("expected strict mode to submit when matches exist")
+	}
+	if !updated.quitting {
+		t.Fatal("expected strict mode to quit after a successful submit")
 	}
 }


### PR DESCRIPTION
  ### Changes
  - keep `gum filter` strict mode open when pressing Enter with
  no matches and no selected items
  - add focused regression coverage for strict-submit behavior
  with and without matches
  - keep the change scoped to `filter/filter.go` and `filter/
  filter_test.go`

  ### Why
  In strict mode, pressing Enter with no remaining matches
  currently exits/submits even though there is nothing valid to
  select. This keeps the interaction open until the user has a
  valid match or explicitly cancels.

  ### Verification
  - `go test ./filter`
  - manual CLI smoke path from the benchmark run:
    - `printf 'zzz\r\003' | script -qfec 'gum filter apple
  banana' /dev/null`
    - expected behavior: Enter on an empty strict filter no
  longer submits/quits; Ctrl-C exits the session


