### PR TITLE
 filter: guard zero-match toggle selection

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -444,6 +444,10 @@ func (m *model) CursorDown() {
 }
 
 func (m *model) ToggleSelection() {
+	if len(m.matches) == 0 || m.cursor < 0 || m.cursor >= len(m.matches) {
+		return
+	}
+
 	if _, ok := m.selected[m.matches[m.cursor].Str]; ok {
 		delete(m.selected, m.matches[m.cursor].Str)
 		m.numSelected--

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -4,6 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -72,5 +75,58 @@ func TestToggleSelectionWithNoMatches(t *testing.T) {
 
 	if m.numSelected != 0 {
 		t.Fatalf("expected no selected count, got %d", m.numSelected)
+	}
+}
+
+func TestUpdateIgnoresToggleWhenNoMatches(t *testing.T) {
+	v := viewport.New(0, 0)
+	m := model{
+		textinput: textinput.New(),
+		viewport:  &v,
+		keymap:    defaultKeymap(),
+		selected:  make(map[string]struct{}),
+		limit:     2,
+	}
+	m.keymap.Toggle.SetEnabled(true)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Update panicked with no matches: %v", r)
+		}
+	}()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyNull})
+	got := updated.(model)
+
+	if len(got.selected) != 0 {
+		t.Fatalf("expected no selections, got %d", len(got.selected))
+	}
+}
+
+func TestUpdateIgnoresToggleAndNextWhenNoMatches(t *testing.T) {
+	v := viewport.New(0, 0)
+	m := model{
+		textinput: textinput.New(),
+		viewport:  &v,
+		keymap:    defaultKeymap(),
+		selected:  make(map[string]struct{}),
+		limit:     2,
+	}
+	m.keymap.ToggleAndNext.SetEnabled(true)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Update panicked with no matches: %v", r)
+		}
+	}()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	got := updated.(model)
+
+	if len(got.selected) != 0 {
+		t.Fatalf("expected no selections, got %d", len(got.selected))
+	}
+	if got.cursor != 0 {
+		t.Fatalf("expected cursor to remain at 0, got %d", got.cursor)
 	}
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -57,3 +57,20 @@ func TestByteToChar(t *testing.T) {
 		t.Errorf("expected %+q, got %+q", expect, got)
 	}
 }
+
+func TestToggleSelectionWithNoMatches(t *testing.T) {
+	m := model{
+		selected: make(map[string]struct{}),
+		limit:    2,
+	}
+
+	m.ToggleSelection()
+
+	if len(m.selected) != 0 {
+		t.Fatalf("expected no selected items, got %d", len(m.selected))
+	}
+
+	if m.numSelected != 0 {
+		t.Fatalf("expected no selected count, got %d", m.numSelected)
+	}
+}


### PR DESCRIPTION
  Changes

  - guard filter.ToggleSelection() when the filtered match set
    is empty or the cursor is out of range
  - add focused regressions for zero-match selection flows
  - keep the change scoped to filter/filter.go and filter/
    filter_test.go

  Why

  When filtering reduces the result set to zero, selection-
  toggle paths can still reach ToggleSelection() and index the
  current match unconditionally. This keeps zero-match toggle
  interactions safe and aligns them with the existing no-op
  behavior used by adjacent cursor movement paths.

  Verification

  - go test ./filter

  Coverage added

  - direct guard regression for zero-match ToggleSelection()
  - interactive zero-match toggle regression
  - interactive zero-match toggle-and-next regression
