### PR TITLE
fix: table --print header styles not applied correctly (#936)

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -117,7 +117,7 @@ func (o Options) Run() error {
 			BorderStyle(o.BorderStyle.ToLipgloss()).
 			Border(style.Border[o.Border]).
 			StyleFunc(func(row, _ int) lipgloss.Style {
-				if row == 0 {
+				if row == -1 {
 					return styles.Header
 				}
 				return styles.Cell


### PR DESCRIPTION
Fixes #936

### Changes
- header style applied to row -1 instead of 0

gum table --print was applying header style to the first row of data, after the headers, not the headers. Changed this value to -1 and it works as intended
