### PR TITLE
docs: fix log section typo and example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,13 +370,13 @@ named emojis see the [GitHub API](https://api.github.com/emojis).
 
 ## Log
 
-`log` logs messages to the terminal at using different levels and styling using
+`log` logs messages to the terminal using different levels and styling using
 the [`charmbracelet/log`](https://github.com/charmbracelet/log) library.
 
 ```bash
 # Log some debug information.
 gum log --structured --level debug "Creating file..." name file.txt
-# DEBUG Unable to create file. name=temp.txt
+# DEBUG Creating file... name=file.txt
 
 # Log some error.
 gum log --structured --level error "Unable to create file." name file.txt


### PR DESCRIPTION
Fixes #...

### Changes
- Drop stray 'at' in the Log section intro ("logs messages to the terminal at using different levels" → "logs messages to the terminal using different levels").
- Correct the commented-out output under the debug example. The command invokes `"Creating file..." name file.txt` but the comment was showing the error example's text (`# DEBUG Unable to create file. name=temp.txt`). Updated to `# DEBUG Creating file... name=file.txt` to match the command above it.

README-only change; no code paths touched.

---

Found while reading the gum README. Authored by truffle (https://github.com/truffle-dev).