### PR TITLE
test: add unit tests for style, decode, exit, files, timeout (#818)

### DIFF
--- a/internal/decode/align_test.go
+++ b/internal/decode/align_test.go
@@ -1,0 +1,33 @@
+package decode
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestAlign(t *testing.T) {
+	for name, want := range map[string]lipgloss.Position{
+		"center": lipgloss.Center,
+		"left":   lipgloss.Left,
+		"top":    lipgloss.Top,
+		"bottom": lipgloss.Bottom,
+		"right":  lipgloss.Right,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, ok := Align[name]
+			if !ok {
+				t.Fatalf("Align map missing key %q", name)
+			}
+			if got != want {
+				t.Errorf("Align[%q] = %v, want %v", name, got, want)
+			}
+		})
+	}
+}
+
+func TestAlignSize(t *testing.T) {
+	if got, want := len(Align), 5; got != want {
+		t.Errorf("Align map size = %d, want %d", got, want)
+	}
+}

--- a/internal/exit/exit_test.go
+++ b/internal/exit/exit_test.go
@@ -1,0 +1,32 @@
+package exit
+
+import "testing"
+
+func TestErrExitError(t *testing.T) {
+	for name, tt := range map[string]struct {
+		code ErrExit
+		want string
+	}{
+		"zero":         {code: 0, want: "exit 0"},
+		"one":          {code: 1, want: "exit 1"},
+		"timeout":      {code: StatusTimeout, want: "exit 124"},
+		"aborted":      {code: StatusAborted, want: "exit 130"},
+		"large value":  {code: 255, want: "exit 255"},
+		"negative one": {code: -1, want: "exit -1"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.code.Error(); got != tt.want {
+				t.Errorf("ErrExit(%d).Error() = %q, want %q", int(tt.code), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusConstants(t *testing.T) {
+	if StatusTimeout != 124 {
+		t.Errorf("StatusTimeout = %d, want 124", StatusTimeout)
+	}
+	if StatusAborted != 130 {
+		t.Errorf("StatusAborted = %d, want 130", StatusAborted)
+	}
+}

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -1,0 +1,26 @@
+package files
+
+import "testing"
+
+func TestShouldIgnore(t *testing.T) {
+	for name, tt := range map[string]struct {
+		path string
+		want bool
+	}{
+		"git dir":              {path: ".git", want: true},
+		"git nested":           {path: ".git/HEAD", want: true},
+		"node_modules dir":     {path: "node_modules", want: true},
+		"node_modules nested":  {path: "node_modules/foo/bar.js", want: true},
+		"hidden file":          {path: ".env", want: true},
+		"current dir prefix":   {path: ".", want: true},
+		"regular file":         {path: "main.go", want: false},
+		"nested regular":       {path: "src/foo.go", want: false},
+		"file with dot inside": {path: "foo.bar", want: false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := shouldIgnore(tt.path); got != tt.want {
+				t.Errorf("shouldIgnore(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/timeout/context_test.go
+++ b/internal/timeout/context_test.go
@@ -1,0 +1,60 @@
+package timeout
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestContextZeroTimeout(t *testing.T) {
+	ctx, cancel := Context(0)
+	defer cancel()
+
+	if _, ok := ctx.Deadline(); ok {
+		t.Errorf("expected no deadline when timeout is 0")
+	}
+	if err := ctx.Err(); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestContextWithTimeout(t *testing.T) {
+	ctx, cancel := Context(50 * time.Millisecond)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatalf("expected a deadline when timeout > 0")
+	}
+	if time.Until(deadline) <= 0 {
+		t.Errorf("expected deadline in the future, got %v", deadline)
+	}
+}
+
+func TestContextDeadlineExceeded(t *testing.T) {
+	ctx, cancel := Context(10 * time.Millisecond)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		if err := ctx.Err(); err != context.DeadlineExceeded {
+			t.Errorf("expected context.DeadlineExceeded, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Error("context did not time out within expected window")
+	}
+}
+
+func TestContextCancelable(t *testing.T) {
+	ctx, cancel := Context(time.Hour)
+	cancel()
+
+	select {
+	case <-ctx.Done():
+		if err := ctx.Err(); err != context.Canceled {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Error("context did not cancel after cancel()")
+	}
+}

--- a/style/borders_test.go
+++ b/style/borders_test.go
@@ -1,0 +1,16 @@
+package style
+
+import "testing"
+
+func TestBorderKeys(t *testing.T) {
+	// All border keys advertised in the CLI enum must be present in the map.
+	wantKeys := []string{"double", "hidden", "none", "normal", "rounded", "thick"}
+	for _, key := range wantKeys {
+		if _, ok := Border[key]; !ok {
+			t.Errorf("Border map missing key %q", key)
+		}
+	}
+	if got, want := len(Border), len(wantKeys); got != want {
+		t.Errorf("Border map size = %d, want %d", got, want)
+	}
+}

--- a/style/spacing_test.go
+++ b/style/spacing_test.go
@@ -1,0 +1,71 @@
+package style
+
+import "testing"
+
+func TestParsePadding(t *testing.T) {
+	for name, tt := range map[string]struct {
+		in                       string
+		top, right, bottom, left int
+	}{
+		"single token": {
+			in:     "2",
+			top:    2,
+			right:  2,
+			bottom: 2,
+			left:   2,
+		},
+		"two tokens": {
+			in:     "1 3",
+			top:    1,
+			right:  3,
+			bottom: 1,
+			left:   3,
+		},
+		"four tokens": {
+			in:     "1 2 3 4",
+			top:    1,
+			right:  2,
+			bottom: 3,
+			left:   4,
+		},
+		"three tokens (unsupported, returns zeros)": {
+			in: "1 2 3",
+		},
+		"five tokens (over max)": {
+			in: "1 2 3 4 5",
+		},
+		"non-integer token": {
+			in: "abc",
+		},
+		"empty string": {
+			in: "",
+		},
+		"zero values": {
+			in: "0 0 0 0",
+		},
+		"negative values": {
+			in:     "-1 -2",
+			top:    -1,
+			right:  -2,
+			bottom: -1,
+			left:   -2,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			top, right, bottom, left := ParsePadding(tt.in)
+			if top != tt.top || right != tt.right || bottom != tt.bottom || left != tt.left {
+				t.Errorf("expected (%d, %d, %d, %d), got (%d, %d, %d, %d)",
+					tt.top, tt.right, tt.bottom, tt.left,
+					top, right, bottom, left)
+			}
+		})
+	}
+}
+
+func TestParseMargin(t *testing.T) {
+	// parseMargin is an alias of ParsePadding; verify aliasing holds.
+	top, right, bottom, left := parseMargin("2 4")
+	if top != 2 || right != 4 || bottom != 2 || left != 4 {
+		t.Errorf("expected (2, 4, 2, 4), got (%d, %d, %d, %d)", top, right, bottom, left)
+	}
+}


### PR DESCRIPTION
## Summary
Refs #818. Adds table-driven tests for pure helpers across 5 packages.

## Packages newly tested
- `style` — `ParsePadding` / `parseMargin` (9 cases including edge cases) + `Border` map keys
- `internal/decode` — `Align` map (5 entries + size check)
- `internal/exit` — `ErrExit.Error()` (6 cases) + status constants
- `internal/files` — `shouldIgnore` (9 cases)
- `internal/timeout` — `Context` (zero timeout, deadline, expiry, cancel — 4 tests)

## Files changed
6 new `*_test.go` files, ~30 sub-tests, +238 lines. Followed the existing `for name, tt := range map[string]struct{...}` table pattern from `filter/filter_test.go`.

## Test plan
- `go test ./...` passes (filter + 5 new packages all `ok`)
- `go vet ./...` clean
- `gofmt -w .` applied (only on new files)
