### PR TITLE
build: update Go toolchain for CVE-2025-68121

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   goreleaser:
     uses: charmbracelet/meta/.github/workflows/goreleaser.yml@main
+    with:
+      go_version: "1.25.8"
     secrets:
       docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
       docker_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   nightly:
     uses: charmbracelet/meta/.github/workflows/nightly.yml@main
+    with:
+      go_version: "1.25.8"
     secrets:
       docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
       docker_token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes [CVE-2025-68121](https://nvd.nist.gov/vuln/detail/cve-2025-68121) exposure in future release artifacts.

### Changes
- Pin the reusable GoReleaser workflow to Go 1.25.8, matching the current `go.mod` version.
- Pin the matching nightly GoReleaser workflow to Go 1.25.8 as well.
- Avoid building release-like binaries with whatever `stable` resolves to on release day.

### Context
Trivy reports `charmbracelet/gum` v0.17.0 release as a Go binary affected by stdlib `CVE-2025-68121` with CRITICAL severity.

That released binary appears to have been built with Go v1.25.1. Trivy lists the fixed Go stdlib versions as 1.24.13, 1.25.7, and 1.26.0-rc.3. This pins future Gum GoReleaser builds to Go 1.25.8, which is already the project's declared Go version and is newer than the fixed 1.25.7 patch.

This is not going to be easy for me to test this myself since it's a CI change