### PR TITLE
fix(style): support common named foreground/background colors

### DIFF
--- a/style/colors.go
+++ b/style/colors.go
@@ -1,0 +1,25 @@
+package style
+
+import "strings"
+
+// namedColors maps common color names to hex values for gum style flags.
+var namedColors = map[string]string{
+	"black":   "#000000",
+	"red":     "#FF0000",
+	"green":   "#00FF00",
+	"yellow":  "#FFFF00",
+	"blue":    "#0000FF",
+	"magenta": "#FF00FF",
+	"cyan":    "#00FFFF",
+	"white":   "#FFFFFF",
+}
+
+func resolveColor(value string) string {
+	if value == "" {
+		return value
+	}
+	if hex, ok := namedColors[strings.ToLower(value)]; ok {
+		return hex
+	}
+	return value
+}

--- a/style/colors_test.go
+++ b/style/colors_test.go
@@ -1,0 +1,14 @@
+package style
+
+import "testing"
+
+func TestResolveColorNamed(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveColor("red"); got != "#FF0000" {
+		t.Fatalf("resolveColor(red) = %q, want #FF0000", got)
+	}
+	if got := resolveColor("#AABBCC"); got != "#AABBCC" {
+		t.Fatalf("resolveColor(hex) = %q, want passthrough", got)
+	}
+}

--- a/style/lipgloss.go
+++ b/style/lipgloss.go
@@ -10,10 +10,10 @@ import (
 // lipgloss.Style.
 func (s Styles) ToLipgloss() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(lipgloss.Color(s.Background)).
-		Foreground(lipgloss.Color(s.Foreground)).
-		BorderBackground(lipgloss.Color(s.BorderBackground)).
-		BorderForeground(lipgloss.Color(s.BorderForeground)).
+		Background(lipgloss.Color(resolveColor(s.Background))).
+		Foreground(lipgloss.Color(resolveColor(s.Foreground))).
+		BorderBackground(lipgloss.Color(resolveColor(s.BorderBackground))).
+		BorderForeground(lipgloss.Color(resolveColor(s.BorderForeground))).
 		Align(decode.Align[s.Align]).
 		Border(Border[s.Border]).
 		Height(s.Height).
@@ -31,10 +31,10 @@ func (s Styles) ToLipgloss() lipgloss.Style {
 // lipgloss.Style.
 func (s StylesNotHidden) ToLipgloss() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(lipgloss.Color(s.Background)).
-		Foreground(lipgloss.Color(s.Foreground)).
-		BorderBackground(lipgloss.Color(s.BorderBackground)).
-		BorderForeground(lipgloss.Color(s.BorderForeground)).
+		Background(lipgloss.Color(resolveColor(s.Background))).
+		Foreground(lipgloss.Color(resolveColor(s.Foreground))).
+		BorderBackground(lipgloss.Color(resolveColor(s.BorderBackground))).
+		BorderForeground(lipgloss.Color(resolveColor(s.BorderForeground))).
 		Align(decode.Align[s.Align]).
 		Border(Border[s.Border]).
 		Height(s.Height).


### PR DESCRIPTION
## Summary

Fixes #980.

Common color names (red, green, blue, etc.) are resolved to hex values for gum style flags.

## Test plan

- [x] `go test ./style/... -v`