### PR TITLE
fix(input): force redraw on resize

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -79,6 +79,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				lipgloss.Width(m.textinput.Prompt) -
 				m.padding[1] - m.padding[3]
 		}
+	return m, tea.ClearScreen
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c":


### PR DESCRIPTION
Fixes #831

## Changes

This updates the `gum input` resize handling path to force a redraw after `tea.WindowSizeMsg`.

Previously, resizing or zooming the terminal could leave stale or duplicated prompt/input renders visible on screen after terminal dimensions changed.

I was able to consistently reproduce this on Linux by resizing or zooming the terminal while interacting with `gum input`.

This change forces the UI to fully refresh after resize events, preventing stale renders from remaining on screen.

## Reproduction

1. Run `gum input`
2. Resize or zoom the terminal while typing
3. Observe duplicated/stale prompt renders

<img width="1172" height="586" alt="image" src="https://github.com/user-attachments/assets/40215c46-f9ff-4554-8030-2ca987ea904b" />

https://github.com/user-attachments/assets/7bc3df51-b2a9-4120-936a-4d96682ce827

