### PR TITLE
feat(log): add GUM_LOG_TIME environment variable for --time

### DIFF
--- a/log/options.go
+++ b/log/options.go
@@ -14,7 +14,7 @@ type Options struct {
 	Level      string `short:"l" help:"The log level to use" enum:"none,debug,info,warn,error,fatal" default:"none"`
 	Prefix     string `help:"Prefix to print before the message"`
 	Structured bool   `short:"s" help:"Use structured logging" xor:"format,structured"`
-	Time       string `short:"t" help:"The time format to use (kitchen, layout, ansic, rfc822, etc...)" default:""`
+	Time       string `short:"t" help:"The time format to use (kitchen, layout, ansic, rfc822, etc...)" default:"" env:"GUM_LOG_TIME"`
 
 	MinLevel string `help:"Minimal level to show" default:"" env:"GUM_LOG_LEVEL"`
 


### PR DESCRIPTION
## Description

Adds an `env:"GUM_LOG_TIME"` binding to the `Time` field of `gum log`'s options, so users can set a consistent time format via the `GUM_LOG_TIME` environment variable — mirroring the existing `GUM_LOG_LEVEL` binding on `MinLevel`.

This addresses the inconsistency noted in #787: time-related styles are already wired up via `envprefix:"GUM_LOG_TIME_"`, but the actual time format flag had no env equivalent, forcing users to either repeat `-t timeonly` on every call or wrap `gum log` in a shell function.

## Verification

```console
$ GUM_LOG_TIME=kitchen gum log hello
8:56AM hello

$ gum log hello
hello

$ gum log -t kitchen hello
8:56AM hello
```

`go build ./...` and `go vet ./log/` both pass cleanly.

Fixes #787