### PR TITLE
fix: nil pointer panic in List() when filepath.Walk encounters errors

### DIFF
--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -13,8 +13,11 @@ func List() []string {
 	var files []string
 	err := filepath.Walk(".",
 		func(path string, info os.FileInfo, err error) error {
-			if shouldIgnore(path) || info.IsDir() || err != nil {
+			if err != nil {
 				return nil //nolint:nilerr
+			}
+			if shouldIgnore(path) || info.IsDir() {
+				return nil
 			}
 			files = append(files, path)
 			return nil

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -1,0 +1,81 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListDoesNotPanicOnPermissionError(t *testing.T) {
+	// Create a temp directory with a file we can't access
+	dir := t.TempDir()
+
+	// Create a normal file
+	if err := os.WriteFile(filepath.Join(dir, "normal.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory with no read permissions
+	unreadableDir := filepath.Join(dir, "unreadable")
+	if err := os.Mkdir(unreadableDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// Restore permissions so cleanup works
+		os.Chmod(unreadableDir, 0o755) //nolint:errcheck
+	})
+
+	// Change to the temp directory
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(origDir) //nolint:errcheck
+	})
+
+	// List should not panic even with permission errors
+	files := List()
+	if len(files) == 0 {
+		t.Log("List returned empty (may be due to permission error), but did not panic")
+	}
+}
+
+func TestListIgnoresGitDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a normal file
+	if err := os.WriteFile(filepath.Join(dir, "normal.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a .git directory with a file
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte("git"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(origDir) //nolint:errcheck
+	})
+
+	files := List()
+	for _, f := range files {
+		if filepath.Base(f) == "config" && filepath.Dir(f) == ".git" {
+			t.Errorf("List should not include .git/config, but got %s", f)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`List()` in `internal/files/files.go` calls `info.IsDir()` before checking `err != nil` in the `filepath.Walk` callback. When `filepath.Walk` encounters an error (e.g., permission denied, broken symlink), the `info` parameter can be **nil**, causing a nil pointer panic.

```go
// Before (buggy): info.IsDir() called before err check
if shouldIgnore(path) || info.IsDir() || err != nil {
    return nil
}
```

## Fix

Reorder the condition to check `err != nil` first, then safely access `info`:

```go
// After: err checked first, info safely accessed after
if err != nil {
    return nil
}
if shouldIgnore(path) || info.IsDir() {
    return nil
}
```

## Testing

Added `files_test.go` with two tests:
- `TestListDoesNotPanicOnPermissionError` — creates an unreadable directory and verifies `List()` does not panic
- `TestListIgnoresGitDir` — verifies `.git` directory contents are excluded

Both pass, along with all existing tests (`go test ./...`).