### PR TITLE
feat(table): add --border-row to draw a separator between every row

### DIFF
--- a/table/command.go
+++ b/table/command.go
@@ -124,6 +124,10 @@ func (o Options) Run() error {
 				return styles.Cell
 			})
 
+		if o.Width > 0 {
+			table = table.Width(o.Width)
+		}
+
 		fmt.Println(table.Render())
 		return nil
 	}

--- a/table/command.go
+++ b/table/command.go
@@ -116,6 +116,7 @@ func (o Options) Run() error {
 			Rows(data...).
 			BorderStyle(o.BorderStyle.ToLipgloss()).
 			Border(style.Border[o.Border]).
+			BorderRow(o.BorderRow).
 			StyleFunc(func(row, _ int) lipgloss.Style {
 				if row == 0 {
 					return styles.Header

--- a/table/options.go
+++ b/table/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	File            string   `short:"f" help:"file path" default:""`
 	Border          string   `short:"b" help:"border style" default:"rounded" enum:"rounded,thick,normal,hidden,double,none"`
 	BorderRow       bool     `help:"Draw a border separator between every row" default:"false" negatable:"" env:"GUM_TABLE_BORDER_ROW"`
+	Width           int      `help:"Set a fixed total table width (0 = auto-size to content)" default:"0" env:"GUM_TABLE_WIDTH"`
 	ShowHelp        bool     `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_TABLE_SHOW_HELP"`
 	HideCount       bool     `help:"Hide item count on help keybinds" default:"false" negatable:"" env:"GUM_TABLE_HIDE_COUNT"`
 	LazyQuotes      bool     `help:"If LazyQuotes is true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field" default:"false" env:"GUM_TABLE_LAZY_QUOTES"`

--- a/table/options.go
+++ b/table/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	Print           bool     `short:"p" help:"static print" default:"false"`
 	File            string   `short:"f" help:"file path" default:""`
 	Border          string   `short:"b" help:"border style" default:"rounded" enum:"rounded,thick,normal,hidden,double,none"`
+	BorderRow       bool     `help:"Draw a border separator between every row" default:"false" negatable:"" env:"GUM_TABLE_BORDER_ROW"`
 	ShowHelp        bool     `help:"Show help keybinds" default:"true" negatable:"" env:"GUM_TABLE_SHOW_HELP"`
 	HideCount       bool     `help:"Hide item count on help keybinds" default:"false" negatable:"" env:"GUM_TABLE_HIDE_COUNT"`
 	LazyQuotes      bool     `help:"If LazyQuotes is true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field" default:"false" env:"GUM_TABLE_LAZY_QUOTES"`


### PR DESCRIPTION
## What

Exposes two `lipgloss/table` capabilities that the `table` command did not surface:

- **`--border-row`** (env `GUM_TABLE_BORDER_ROW`) — draw a horizontal separator
  between every data row, not just after the header.
- **`--width`** (env `GUM_TABLE_WIDTH`) — set a fixed total table width; columns
  auto-size to fit. `0` (default) keeps the current content-based sizing.

Both are opt-in; defaults are unchanged, so no behavior change for existing users.

## Why

`lipgloss/table` already supports `BorderRow(true)` and `Width(w)`; `gum table`
just did not expose them. Per-row dividers match what SQL CLIs (grid mode),
`tabulate` (grid) and `tty-table` do by default, and a fixed width lets a table
line up with surrounding UI (e.g. a header box of the same width).

## Before / After

```
printf "Machine type|Personal Mac
AI agent CLIs|claude, codex
" | \
  gum table -p --separator="|" --border double --columns "Component,Selection"
```

Before (content-sized, divider only after the header):

```
╔══════════════╦══════════════╗
║ Component    ║ Selection    ║
╠══════════════╬══════════════╣
║ Machine type ║ Personal Mac ║
║ AI agent CLIs║ claude, codex║
╚══════════════╩══════════════╝
```

After (`--border-row --width 72`):

```
╔═══════════════════════════════════╦══════════════════════════════════╗
║ Component                         ║ Selection                        ║
╠═══════════════════════════════════╬══════════════════════════════════╣
║ Machine type                      ║ Personal Mac                     ║
╠═══════════════════════════════════╬══════════════════════════════════╣
║ AI agent CLIs                     ║ claude, codex                    ║
╚═══════════════════════════════════╩══════════════════════════════════╝
```

