### PR TITLE
Preserve time key in structured log context

### DIFF
--- a/log/command.go
+++ b/log/command.go
@@ -108,10 +108,7 @@ func (o Options) Run() error {
 	}
 
 	if len(o.Text) > 1 {
-		args = make([]interface{}, len(o.Text[1:]))
-		for i, arg := range o.Text[1:] {
-			args[i] = arg
-		}
+		args = logArgs(o.Text[1:], o.Structured)
 	}
 
 	logger := map[string]logger{
@@ -137,6 +134,24 @@ func (o Options) Run() error {
 type logger struct {
 	printf func(string, ...interface{})
 	print  func(interface{}, ...interface{})
+}
+
+type structuredKey string
+
+func (k structuredKey) String() string {
+	return string(k)
+}
+
+func logArgs(text []string, structured bool) []interface{} {
+	args := make([]interface{}, len(text))
+	for i, arg := range text {
+		if structured && i%2 == 0 {
+			args[i] = structuredKey(arg)
+			continue
+		}
+		args[i] = arg
+	}
+	return args
 }
 
 var levelToLog = map[string]log.Level{

--- a/log/command_test.go
+++ b/log/command_test.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStructuredLogPreservesTimeContextKey(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "gum.log")
+
+	err := (Options{
+		File:       out,
+		Formatter:  "text",
+		Level:      "none",
+		Structured: true,
+		Text: []string{
+			"Test log message",
+			"time", "0",
+			"normal_var_name", "0",
+			"time", "0",
+		},
+	}).Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("expected log file to be written: %v", err)
+	}
+
+	got := string(data)
+	if count := strings.Count(got, "time=0"); count != 2 {
+		t.Fatalf("expected two time context values in %q, got %d", got, count)
+	}
+
+	if !strings.Contains(got, "normal_var_name=0") {
+		t.Fatalf("expected normal context value in %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #967

### Changes
- Preserve user-provided structured log keys named `time` instead of treating them as the logger timestamp field.
- Add regression coverage for repeated `time` context keys in `gum log --structured`.

### Testing
- `go test ./log`
- `go test ./...`
- `git diff --check`