### PR TITLE
fix(style): support 3-value padding/margin shorthand

### DIFF
--- a/style/spacing.go
+++ b/style/spacing.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	minTokens  = 1
-	halfTokens = 2
-	maxTokens  = 4
+	minTokens   = 1
+	halfTokens  = 2
+	threeTokens = 3
+	maxTokens   = 4
 )
 
 // ParsePadding parses 1 - 4 integers from a string and returns them in a top,
@@ -37,6 +38,10 @@ func ParsePadding(s string) (int, int, int, int) {
 
 	if len(tokens) == halfTokens {
 		return ints[0], ints[1], ints[0], ints[1]
+	}
+
+	if len(tokens) == threeTokens {
+		return ints[0], ints[1], ints[2], ints[1]
 	}
 
 	if len(tokens) == maxTokens {

--- a/style/spacing_test.go
+++ b/style/spacing_test.go
@@ -1,0 +1,28 @@
+package style
+
+import "testing"
+
+func TestParsePadding(t *testing.T) {
+	tests := []struct {
+		name                    string
+		in                      string
+		top, right, bottom, left int
+	}{
+		{"one token applies to all sides", "1", 1, 1, 1, 1},
+		{"two tokens vertical horizontal", "1 2", 1, 2, 1, 2},
+		{"three tokens top horizontal bottom", "1 2 3", 1, 2, 3, 2},
+		{"four tokens clockwise", "1 2 3 4", 1, 2, 3, 4},
+		{"too many tokens is zero", "1 2 3 4 5", 0, 0, 0, 0},
+		{"non-integer is zero", "1 a", 0, 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			top, right, bottom, left := ParsePadding(tt.in)
+			if top != tt.top || right != tt.right || bottom != tt.bottom || left != tt.left {
+				t.Errorf("ParsePadding(%q) = (%d,%d,%d,%d), want (%d,%d,%d,%d)",
+					tt.in, top, right, bottom, left, tt.top, tt.right, tt.bottom, tt.left)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changes

- Fix `--padding`/`--margin` with **3 values** being silently ignored. `ParsePadding` (`style/spacing.go`) handled 1, 2, and 4 tokens but had no branch for 3, so `gum style --padding "1 2 3" "text"` fell through to `(0,0,0,0)` and rendered with no padding.
- Add the missing 3-token branch using the CSS shorthand lipgloss already supports — top / horizontal / bottom → `(top, horizontal, bottom, horizontal)`.
- Add `style/spacing_test.go` with a table test for `ParsePadding` (1/2/3/4 tokens). The 3-token case fails before this change and passes after; `go test ./...` green.
