### PR TITLE
fix(confirm): clear screen on resize to prevent duplicated prompt text

### DIFF
--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -87,6 +87,8 @@ type model struct {
 
 	defaultSelection bool
 
+	width int
+
 	// styles
 	promptStyle     lipgloss.Style
 	selectedStyle   lipgloss.Style
@@ -99,7 +101,10 @@ func (m model) Init() tea.Cmd { return nil }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		return m, nil
+		m.width = msg.Width
+		// confirm renders inline (no alt screen); clear stale lines when the
+		// viewport changes so wrapped prompt/button text does not linger.
+		return m, tea.ClearScreen
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, m.keys.Abort):
@@ -150,8 +155,13 @@ func (m model) View() string {
 		neg = ""
 	}
 
+	promptStyle := m.promptStyle
+	if width := m.contentWidth(); width > 0 {
+		promptStyle = promptStyle.MaxWidth(width)
+	}
+
 	parts := []string{
-		m.promptStyle.Render(m.prompt) + "\n",
+		promptStyle.Render(m.prompt) + "\n",
 		lipgloss.JoinHorizontal(lipgloss.Left, aff, neg),
 	}
 
@@ -165,4 +175,18 @@ func (m model) View() string {
 			lipgloss.Left,
 			parts...,
 		))
+}
+
+func (m model) contentWidth() int {
+	if m.width == 0 {
+		return 0
+	}
+	horizontalPadding := 0
+	if len(m.padding) > 1 {
+		horizontalPadding += m.padding[1]
+	}
+	if len(m.padding) > 3 {
+		horizontalPadding += m.padding[3]
+	}
+	return m.width - horizontalPadding
 }

--- a/confirm/confirm_test.go
+++ b/confirm/confirm_test.go
@@ -1,0 +1,40 @@
+package confirm
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestWindowSizeMsgClearsScreen(t *testing.T) {
+	m := model{
+		prompt:      "do you confirm?",
+		affirmative: "yes",
+		negative:    "no",
+		padding:     []int{0, 0, 0, 0},
+	}
+
+	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	next := updated.(model)
+
+	if next.width != 80 {
+		t.Fatalf("expected window width to be stored, got %d", next.width)
+	}
+	if cmd == nil {
+		t.Fatal("expected ClearScreen command on resize")
+	}
+	if reflect.ValueOf(cmd).Pointer() != reflect.ValueOf(tea.ClearScreen).Pointer() {
+		t.Fatalf("expected tea.ClearScreen command, got %#v", cmd)
+	}
+}
+
+func TestContentWidthAccountsForPadding(t *testing.T) {
+	m := model{
+		width:   100,
+		padding: []int{1, 2, 3, 4},
+	}
+	if got := m.contentWidth(); got != 94 {
+		t.Fatalf("expected content width 94, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a terminal resize artifact in `gum confirm` where the prompt (and sometimes buttons) appeared duplicated after shrinking and growing the viewport.

## Motivation

Fixes #426. `gum confirm` renders inline (no alt screen). When the terminal width changes, lipgloss-wrapped prompt lines can leave stale content on screen because the new frame may be shorter than the previous one.

## Changes

- Store terminal width on `tea.WindowSizeMsg`
- Return `tea.ClearScreen` on resize to remove stale wrapped lines before redraw
- Apply `MaxWidth` to the prompt based on available content width (terminal width minus horizontal padding)
- Add unit tests for resize handling and content width calculation

## Tests

```bash
go test ./confirm/... -count=1 -v
go test ./... -count=1
```

Result: **PASS**

## Notes

- Reviewed with composer-2.5: **APPROVE**
- Manual resize repro from the issue should be verified in a real terminal when possible
