### PR TITLE
fix(pager): prevent last line from being clipped offscreen

### DIFF
--- a/pager/pager.go
+++ b/pager/pager.go
@@ -126,7 +126,9 @@ func (m *model) helpView() string {
 }
 
 func (m *model) processText(msg tea.WindowSizeMsg) {
-	m.viewport.Height = msg.Height - lipgloss.Height(m.helpView())
+	// Reserve one line for the separator between viewport content and the help
+	// bar rendered in View().
+	m.viewport.Height = msg.Height - lipgloss.Height(m.helpView()) - 1
 	m.viewport.Width = msg.Width
 	textStyle := lipgloss.NewStyle().Width(m.viewport.Width)
 	var text strings.Builder

--- a/pager/pager_test.go
+++ b/pager/pager_test.go
@@ -1,0 +1,36 @@
+package pager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestProcessTextViewportHeightAccountsForHelpAndSeparator(t *testing.T) {
+	m := model{
+		viewport:    viewport.New(80, 0),
+		help:        help.New(),
+		content:     strings.Repeat("line\n", 50),
+		origContent: strings.Repeat("line\n", 50),
+		keymap:      defaultKeymap(),
+		softWrap:    false,
+	}
+
+	const termHeight = 24
+	m.processText(tea.WindowSizeMsg{Height: termHeight, Width: 80})
+
+	helpHeight := lipgloss.Height(m.helpView())
+	want := termHeight - helpHeight - 1
+	if m.viewport.Height != want {
+		t.Fatalf("viewport.Height = %d, want %d (terminal=%d help=%d)", m.viewport.Height, want, termHeight, helpHeight)
+	}
+
+	viewHeight := lipgloss.Height(m.View())
+	if viewHeight > termHeight {
+		t.Fatalf("rendered view height %d exceeds terminal height %d", viewHeight, termHeight)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the last line of pager content being clipped/hidden when scrolled to the bottom.

## Motivation

When viewing content with `gum pager`, the last visible line could be pushed below the viewport. This happens because `View()` renders `viewport + "\n" + helpView`, but `processText()` only subtracted the help bar height — not the separator newline between them.

Repro: `cat README.md | gum pager`, scroll to bottom with `G`.

Fixes #797

## Changes

- Reserve one additional terminal row in `processText()` when calculating `viewport.Height`
- Add `pager_test.go` with a regression test verifying the height formula and that rendered output fits within the terminal

## Tests

```bash
go test ./pager/... -v
go test ./...
```

All tests pass.

## Notes

- A previous attempt (#1053) proposed the same one-line fix but was closed when a maintainer could not reproduce. This PR adds a unit test that fails without the fix and documents the layout math.
- `heightOffset` used during search navigation was reviewed and does not need adjustment with this change.