### PR TITLE
fix(pager): keep viewport size stable when jumping search matches

### DIFF
--- a/pager/pager.go
+++ b/pager/pager.go
@@ -101,6 +101,8 @@ type model struct {
 	matchHighlightStyle lipgloss.Style
 	maxWidth            int
 	keymap              keymap
+	width               int
+	height              int
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -108,7 +110,9 @@ func (m model) Init() tea.Cmd { return nil }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.processText(msg)
+		m.width = msg.Width
+		m.height = msg.Height
+		m.processText()
 	case tea.KeyMsg:
 		return m.keyHandler(msg)
 	}
@@ -125,9 +129,13 @@ func (m *model) helpView() string {
 	return m.help.View(m.keymap)
 }
 
-func (m *model) processText(msg tea.WindowSizeMsg) {
-	m.viewport.Height = msg.Height - lipgloss.Height(m.helpView())
-	m.viewport.Width = msg.Width
+func (m *model) processText() string {
+	if m.height == 0 {
+		return ""
+	}
+
+	m.viewport.Height = m.height - lipgloss.Height(m.helpView())
+	m.viewport.Width = m.width
 	textStyle := lipgloss.NewStyle().Width(m.viewport.Width)
 	var text strings.Builder
 
@@ -168,10 +176,10 @@ func (m *model) processText(msg tea.WindowSizeMsg) {
 		remainingLines := "   ~ │ " + strings.Repeat("\n   ~ │ ", diffHeight-1)
 		text.WriteString(m.lineNumberStyle.Render(remainingLines))
 	}
-	m.viewport.SetContent(text.String())
+	rendered := text.String()
+	m.viewport.SetContent(rendered)
+	return rendered
 }
-
-const heightOffset = 2
 
 func (m model) keyHandler(msg tea.KeyMsg) (model, tea.Cmd) {
 	km := m.keymap
@@ -185,7 +193,7 @@ func (m model) keyHandler(msg tea.KeyMsg) (model, tea.Cmd) {
 
 				// Trigger a view update to highlight the found matches.
 				m.search.NextMatch(&m)
-				m.processText(tea.WindowSizeMsg{Height: m.viewport.Height + heightOffset, Width: m.viewport.Width})
+				m.search.alignViewport(&m, m.processText())
 			} else {
 				m.search.Done()
 			}
@@ -205,10 +213,10 @@ func (m model) keyHandler(msg tea.KeyMsg) (model, tea.Cmd) {
 			return m, textinput.Blink
 		case key.Matches(msg, km.PrevMatch):
 			m.search.PrevMatch(&m)
-			m.processText(tea.WindowSizeMsg{Height: m.viewport.Height + heightOffset, Width: m.viewport.Width})
+			m.search.alignViewport(&m, m.processText())
 		case key.Matches(msg, km.NextMatch):
 			m.search.NextMatch(&m)
-			m.processText(tea.WindowSizeMsg{Height: m.viewport.Height + heightOffset, Width: m.viewport.Width})
+			m.search.alignViewport(&m, m.processText())
 		case key.Matches(msg, km.Quit):
 			return m, tea.Quit
 		case key.Matches(msg, km.Abort):

--- a/pager/pager_test.go
+++ b/pager/pager_test.go
@@ -1,0 +1,54 @@
+package pager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/viewport"
+)
+
+func TestProcessTextPreservesViewportHeightAcrossMatchNavigation(t *testing.T) {
+	m := model{
+		viewport:        viewport.New(80, 24),
+		help:            help.New(),
+		content:         strings.Repeat("match line\n", 200),
+		showLineNumbers: true,
+		keymap:          defaultKeymap(),
+		width:           80,
+		height:          24,
+	}
+
+	m.processText()
+	initialHeight := m.viewport.Height
+
+	for range 5 {
+		m.processText()
+	}
+
+	if m.viewport.Height != initialHeight {
+		t.Fatalf("viewport height drifted from %d to %d after repeated processText calls", initialHeight, m.viewport.Height)
+	}
+}
+
+func TestAlignViewportUsesRenderedContentLine(t *testing.T) {
+	m := model{
+		viewport:        viewport.New(40, 10),
+		help:            help.New(),
+		content:         strings.Repeat("filler\n", 50) + "match here",
+		showLineNumbers: false,
+		softWrap:        false,
+		keymap:          defaultKeymap(),
+		width:           40,
+		height:          10,
+	}
+
+	rendered := m.processText()
+	m.viewport.SetYOffset(40)
+	m.search.matchLipglossStr = "match here"
+	m.search.alignViewport(&m, rendered)
+
+	if m.viewport.YOffset <= 40 {
+		t.Fatalf("expected viewport to scroll toward match below view, got %d", m.viewport.YOffset)
+	}
+}

--- a/pager/search.go
+++ b/pager/search.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/x/ansi"
 )
 
 type search struct {
@@ -89,19 +88,6 @@ func (s *search) NextMatch(m *model) {
 	s.matchString = m.content[match[0]:match[1]]
 	s.matchLipglossStr = m.matchHighlightStyle.Render(s.matchString[leftPad : len(s.matchString)-rightPad])
 	m.content = lhs + strings.Replace(rhs, m.content[match[0]:match[1]], s.matchLipglossStr, 1)
-
-	// Update the viewport position.
-	var line int
-	formatStr := softWrapEm(m.content, m.maxWidth, m.softWrap)
-	index := strings.Index(formatStr, s.matchLipglossStr)
-	if index != -1 {
-		line = strings.Count(formatStr[:index], "\n")
-	}
-
-	// Only update if the match is not within the viewport.
-	if index != -1 && (line > m.viewport.YOffset-1+m.viewport.VisibleLineCount()-1 || line < m.viewport.YOffset) {
-		m.viewport.SetYOffset(line)
-	}
 }
 
 func (s *search) PrevMatch(m *model) {
@@ -131,39 +117,24 @@ func (s *search) PrevMatch(m *model) {
 	s.matchString = m.content[match[0]:match[1]]
 	s.matchLipglossStr = m.matchHighlightStyle.Render(s.matchString[leftPad : len(s.matchString)-rightPad])
 	m.content = lhs + strings.Replace(rhs, m.content[match[0]:match[1]], s.matchLipglossStr, 1)
-
-	// Update the viewport position.
-	var line int
-	formatStr := softWrapEm(m.content, m.maxWidth, m.softWrap)
-	index := strings.Index(formatStr, s.matchLipglossStr)
-	if index != -1 {
-		line = strings.Count(formatStr[:index], "\n")
-	}
-
-	// Only update if the match is not within the viewport.
-	if index != -1 && (line > m.viewport.YOffset-1+m.viewport.VisibleLineCount()-1 || line < m.viewport.YOffset) {
-		m.viewport.SetYOffset(line)
-	}
 }
 
-func softWrapEm(str string, maxWidth int, softWrap bool) string {
-	var text strings.Builder
-	for _, line := range strings.Split(str, "\n") {
-		idx := 0
-		if w := ansi.StringWidth(line); softWrap && w > maxWidth {
-			for w > idx {
-				truncatedLine := ansi.Cut(line, idx, maxWidth+idx)
-				idx += maxWidth
-				text.WriteString(truncatedLine)
-				text.WriteString("\n")
-			}
-		} else {
-			text.WriteString(line)
-			text.WriteString("\n")
-		}
+func (s *search) alignViewport(m *model, rendered string) {
+	if s.matchLipglossStr == "" || rendered == "" {
+		return
 	}
 
-	return text.String()
+	index := strings.Index(rendered, s.matchLipglossStr)
+	if index == -1 {
+		return
+	}
+
+	line := strings.Count(rendered[:index], "\n")
+
+	// Only update if the match is not within the viewport.
+	if line > m.viewport.YOffset+m.viewport.VisibleLineCount()-1 || line < m.viewport.YOffset {
+		m.viewport.SetYOffset(line)
+	}
 }
 
 // lipglossPadding calculates how much padding a string is given by a style.


### PR DESCRIPTION
## Summary

Fix `gum pager` losing the ability to scroll to the top after navigating search matches with `n` / `N`.

## Motivation

When jumping between search results, the pager rebuilt its viewport using a synthetic window height derived from the current viewport height (`viewport.Height + 2`). Each navigation inflated the viewport size, which broke scroll bounds and could clip the help bar (#1087).

## Changes

- Store the real terminal `width` / `height` from `WindowSizeMsg` on the pager model.
- Re-render content from the stored terminal size on every match jump instead of passing a fabricated `WindowSizeMsg`.
- Move viewport alignment into `alignViewport()` so scrolling uses the rendered content line index after line numbers and soft-wrap are applied.
- Add regression tests for viewport height stability and match scrolling.

## Tests

- `go test ./pager/... -v` — PASS
- `go build ./...` — PASS
- composer-2.5 review — APPROVE

## Notes

This is a minimal fix focused on the viewport height drift described in the issue. Manual TUI verification on macOS would still be valuable, but the regression tests cover the failure mode directly.

Fixes #1087