### PR TITLE
fix(style): resolve named colors like red/blue for --foreground

### DIFF
--- a/style/colors.go
+++ b/style/colors.go
@@ -1,0 +1,45 @@
+package style
+
+import "strings"
+
+// namedANSIColors maps the 16 standard ANSI terminal color names to the
+// numeric ANSI color codes lipgloss.Color already understands (see
+// https://github.com/charmbracelet/lipgloss/blob/master/color.go). Using
+// the numeric codes (instead of hardcoded hex values) preserves lipgloss's
+// automatic color degradation across ANSI, ANSI256, and TrueColor profiles.
+var namedANSIColors = map[string]string{
+	"black":         "0",
+	"red":           "1",
+	"green":         "2",
+	"yellow":        "3",
+	"blue":          "4",
+	"magenta":       "5",
+	"cyan":          "6",
+	"white":         "7",
+	"brightblack":   "8",
+	"brightred":     "9",
+	"brightgreen":   "10",
+	"brightyellow":  "11",
+	"brightblue":    "12",
+	"brightmagenta": "13",
+	"brightcyan":    "14",
+	"brightwhite":   "15",
+}
+
+// resolveColor maps a common named color (e.g. "red") to the ANSI color
+// code lipgloss.Color expects, so that flags like --foreground/--background
+// accept human readable names in addition to hex codes and ANSI numbers.
+//
+// See https://github.com/charmbracelet/gum/issues/980: previously, an
+// unrecognized name like "red" was passed straight to lipgloss.Color,
+// which silently rendered no color at all.
+//
+// Values that are not a recognized name (hex codes, ANSI numbers, or truly
+// unsupported strings) are returned unchanged so lipgloss/termenv continue
+// to handle them exactly as before.
+func resolveColor(value string) string {
+	if code, ok := namedANSIColors[strings.ToLower(strings.TrimSpace(value))]; ok {
+		return code
+	}
+	return value
+}

--- a/style/colors_test.go
+++ b/style/colors_test.go
@@ -1,0 +1,30 @@
+package style
+
+import "testing"
+
+// TestResolveColor asserts that common named colors (as reported in
+// https://github.com/charmbracelet/gum/issues/980) resolve to a valid
+// ANSI color value that lipgloss.Color understands, while values that are
+// already valid (hex codes, ANSI numbers) or unrecognized pass through
+// unchanged.
+func TestResolveColor(t *testing.T) {
+	for name, tt := range map[string]struct {
+		in   string
+		want string
+	}{
+		"named color lowercase":                              {in: "red", want: "1"},
+		"named color uppercase":                              {in: "RED", want: "1"},
+		"named color mixed case with surrounding whitespace": {in: " Blue ", want: "4"},
+		"bright variant":                                     {in: "brightcyan", want: "14"},
+		"hex passthrough":                                    {in: "#FF0000", want: "#FF0000"},
+		"ansi number passthrough":                            {in: "212", want: "212"},
+		"unknown name passthrough":                           {in: "notacolor", want: "notacolor"},
+		"empty passthrough":                                  {in: "", want: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := resolveColor(tt.in); got != tt.want {
+				t.Errorf("resolveColor(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/style/lipgloss.go
+++ b/style/lipgloss.go
@@ -10,10 +10,10 @@ import (
 // lipgloss.Style.
 func (s Styles) ToLipgloss() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(lipgloss.Color(s.Background)).
-		Foreground(lipgloss.Color(s.Foreground)).
-		BorderBackground(lipgloss.Color(s.BorderBackground)).
-		BorderForeground(lipgloss.Color(s.BorderForeground)).
+		Background(lipgloss.Color(resolveColor(s.Background))).
+		Foreground(lipgloss.Color(resolveColor(s.Foreground))).
+		BorderBackground(lipgloss.Color(resolveColor(s.BorderBackground))).
+		BorderForeground(lipgloss.Color(resolveColor(s.BorderForeground))).
 		Align(decode.Align[s.Align]).
 		Border(Border[s.Border]).
 		Height(s.Height).
@@ -31,10 +31,10 @@ func (s Styles) ToLipgloss() lipgloss.Style {
 // lipgloss.Style.
 func (s StylesNotHidden) ToLipgloss() lipgloss.Style {
 	return lipgloss.NewStyle().
-		Background(lipgloss.Color(s.Background)).
-		Foreground(lipgloss.Color(s.Foreground)).
-		BorderBackground(lipgloss.Color(s.BorderBackground)).
-		BorderForeground(lipgloss.Color(s.BorderForeground)).
+		Background(lipgloss.Color(resolveColor(s.Background))).
+		Foreground(lipgloss.Color(resolveColor(s.Foreground))).
+		BorderBackground(lipgloss.Color(resolveColor(s.BorderBackground))).
+		BorderForeground(lipgloss.Color(resolveColor(s.BorderForeground))).
 		Align(decode.Align[s.Align]).
 		Border(Border[s.Border]).
 		Height(s.Height).


### PR DESCRIPTION
`gum style --foreground red` rendered no color. Named ANSI colors were passed straight to `lipgloss.Color()`, which only parses hex and numeric ANSI codes, so names silently produced nothing while hex worked.

Adds a map from the 16 standard ANSI color names to their numeric codes, wired into both `ToLipgloss()` methods (the single point every gum command's style flags go through). Unknown values (hex, ANSI numbers, anything else) pass through unchanged. Numeric codes are used rather than hardcoded hex so lipgloss keeps its color-profile downgrade.

Before, `--foreground red` printed no SGR code; after, it prints `\e[31m`. Added a test covering named/bright/hex/ansi/unknown, verified failing before the fix. `go test ./...`, vet and lint clean.

Closes #980
