### PR TITLE
feat: choose report/questionnaire mode (#1099)

### DIFF
--- a/choose/command.go
+++ b/choose/command.go
@@ -172,11 +172,16 @@ func (o Options) Run() error {
 	}
 
 	var out []string
+	if o.Header != "" {
+		out = append(out, o.Header)
+	}
+
 	for _, item := range m.items {
 		if item.selected {
 			out = append(out, options[item.text])
 		}
 	}
+
 	tty.Println(strings.Join(out, o.OutputDelimiter))
 	return nil
 }


### PR DESCRIPTION
Fixes #1099 
For extra context when choosing a value under a header, Headers are now logged to stdout 

### Changes
- now the header field from the Options struct is appended to the Output

Results after changing : 
<img width="1693" height="121" alt="image" src="https://github.com/user-attachments/assets/e4c551db-dcd4-47d4-a393-e4ef2cab8ff8" />

