### PR TITLE
fix(log) Add newline preservation in log output

### DIFF
--- a/log/command.go
+++ b/log/command.go
@@ -81,8 +81,7 @@ func (o Options) Run() error {
 		Inline(true)
 	st.Prefix = o.PrefixStyle.ToLipgloss().
 		Inline(true)
-	st.Message = o.MessageStyle.ToLipgloss().
-		Inline(true)
+	st.Message = o.MessageStyle.ToLipgloss()
 	st.Key = o.KeyStyle.ToLipgloss().
 		Inline(true)
 	st.Value = o.ValueStyle.ToLipgloss().
@@ -128,7 +127,7 @@ func (o Options) Run() error {
 	} else if o.Structured {
 		logger.print(arg0, args...)
 	} else {
-		logger.print(strings.Join(o.Text, " "))
+		logger.print(strings.Join(o.Text, "\n"))
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #1109 

### Changes
The `gum log` command was joining multiple text arguments with a space, which collapsed embedded newlines into a single
line. This changes the join delimiter to `"\n"` to match `gum style`, so newlines supplied in arguments are preserved in
output.

You can test these changes using the original issue's example:

```
git log "this
is
a
test
"
```
will output on newlines should now like so:
```
this
is
a
test
```
