### PR TITLE
test: add unit tests for join package

### DIFF
--- a/join/join_test.go
+++ b/join/join_test.go
@@ -1,0 +1,38 @@
+package join
+
+import "testing"
+
+func TestJoinHorizontal(t *testing.T) {
+	o := Options{
+		Text:       []string{"Hello", "World"},
+		Align:      "left",
+		Horizontal: true,
+	}
+	if err := o.Run(); err != nil {
+		t.Errorf("Horizontal join failed: %v", err)
+	}
+}
+
+func TestJoinVertical(t *testing.T) {
+	o := Options{
+		Text:     []string{"Hello", "World"},
+		Align:    "left",
+		Vertical: true,
+	}
+	if err := o.Run(); err != nil {
+		t.Errorf("Vertical join failed: %v", err)
+	}
+}
+
+func TestJoinAlignMapping(t *testing.T) {
+	for _, a := range []string{"left", "center", "right", "top", "bottom", "middle"} {
+		o := Options{
+			Text:       []string{"A", "B"},
+			Align:      a,
+			Horizontal: true,
+		}
+		if err := o.Run(); err != nil {
+			t.Errorf("Join with align=%q failed: %v", a, err)
+		}
+	}
+}


### PR DESCRIPTION
Add table-driven tests exercising horizontal joins, vertical joins, and all documented alignment values (left, center, right, top, bottom, middle). The join command currently has no test coverage; this gives fast feedback on regressions in option parsing or alignment string-to-Position mapping.

Covers the Run() path deterministically with lipgloss as the only dependency.